### PR TITLE
Fix "window is not defined" when requiring in Node

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,9 @@ module.exports = {
     path: __dirname + "/dist",
     filename: "[name].js",
     library: libraryName,
-    libraryTarget: "umd"
+    libraryTarget: "umd",
+    // Workaround for webpack 4 umd bug (Ref: https://github.com/webpack/webpack/issues/6522)
+    globalObject: "typeof self !== 'undefined' ? self : this"
   },
   resolve: {
     extensions: [".js", ".ts"]


### PR DESCRIPTION
This fixes an issue with the UMD build that was caused by the recent upgrade to Webpack 4.  There is an outstanding [Webpack 4 UMD bug](https://github.com/webpack/webpack/issues/6522) that needs to be worked around to avoid a `window` reference in the output.

Fixes https://github.com/bradymholt/cRonstrue/issues/76