### PR TITLE
change parser to split on one or more spaces between parts

### DIFF
--- a/src/cronParser.ts
+++ b/src/cronParser.ts
@@ -31,7 +31,8 @@ export class CronParser {
       throw new Error("Expression is empty");
     }
 
-    let parsed: string[] = expression.trim().split(" ");
+    // split on one or more spaces
+    let parsed: string[] = expression.trim().split(/[ ]+/);
 
     if (parsed.length < 5) {
       throw new Error(

--- a/test/cronParser.ts
+++ b/test/cronParser.ts
@@ -29,5 +29,10 @@ describe("CronParser", function() {
         new CronParser("* * * * MO").parse();
       }, `DOW part contains invalid values: 'MO'`);
     });
+
+    it("should parse cron with multiple spaces between parts", function() {
+      assert.equal(new CronParser("30  2  *    *  *").parse().length, 7);
+      assert.equal(new CronParser("* *  * *  * 2015").parse().length, 7);
+    });
   });
 });


### PR DESCRIPTION
Came across this issue today.  Looks like the cron-expression-descriptor this was ported from uses the "remove empty elements" flag in their split but since JS doesn't have that, I thought splitting on a regex was the best solution.