### PR TITLE
Added support for Korean language

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This library was ported from the original C# implemenation called [cron-expressi
 - Supports all cron expression special characters including * / , - ? L W, #
 - Supports 5, 6 (w/ seconds or year), or 7 (w/ seconds and year) part cron expressions
 - Supports [Quartz Job Scheduler](http://www.quartz-scheduler.org/) cron expressions
-- i18n support with 24 languages
+- i18n support with 25 languages
 
 ## Installation
 cRonstrue is exported as an [UMD](https://github.com/umdjs/umd) module so it will work in an [AMD](https://github.com/amdjs/amdjs-api/wiki/AMD), [CommonJS](http://wiki.commonjs.org/wiki/CommonJS) or browser global context.
@@ -112,6 +112,7 @@ cronstrue.toString("*/5 * * * *", { locale: "fr" });
 - he - Hebrew
 - it - Italian
 - ja - Japanese
+- ko - Korean
 - nb - Norwegian
 - nl - Dutch
 - pl - Polish

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cronstrue",
-  "version": "1.69.0",
+  "version": "1.70.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7565,6 +7565,15 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -7574,15 +7583,6 @@
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
         "strip-ansi": "^3.0.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "stringstream": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cronstrue",
-  "version": "1.70.0",
+  "version": "1.69.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cronstrue",
   "title": "cRonstrue",
-  "version": "1.70.0",
+  "version": "1.69.0",
   "description": "Convert cron expressions into human readable descriptions",
   "author": "Brady Holt",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cronstrue",
   "title": "cRonstrue",
-  "version": "1.69.0",
+  "version": "1.70.0",
   "description": "Convert cron expressions into human readable descriptions",
   "author": "Brady Holt",
   "license": "MIT",

--- a/src/expressionDescriptor.ts
+++ b/src/expressionDescriptor.ts
@@ -544,10 +544,11 @@ export class ExpressionDescriptor {
 
   protected formatTime(hourExpression: string, minuteExpression: string, secondExpression: string) {
     let hour: number = parseInt(hourExpression);
-
-    let period: string = "";
+    let period: string = '';
+    let setPeriodBeforeTime: boolean = false;
     if (!this.options.use24HourTimeFormat) {
-      period = hour >= 12 ? " PM" : " AM";
+      setPeriodBeforeTime = this.i18n.setPeriodBeforeTime && this.i18n.setPeriodBeforeTime();
+      period = setPeriodBeforeTime ? `${this.getPeriod(hour)} ` : ` ${this.getPeriod(hour)}`;
       if (hour > 12) {
         hour -= 12;
       }
@@ -556,15 +557,15 @@ export class ExpressionDescriptor {
       }
     }
 
-    let minute = minuteExpression;
-    let second: string = "";
+    const minute = minuteExpression;
+    let second: string = '';
     if (secondExpression) {
-      second = `:${("00" + secondExpression).substring(secondExpression.length)}`;
+      second = `:${('00' + secondExpression).substring(secondExpression.length)}`;
     }
 
-    return `${("00" + hour.toString()).substring(hour.toString().length)}:${("00" + minute.toString()).substring(
+    return `${setPeriodBeforeTime ? period : ''}${('00' + hour.toString()).substring(hour.toString().length)}:${('00' + minute.toString()).substring(
       minute.toString().length
-    )}${second}${period}`;
+    )}${second}${!setPeriodBeforeTime ? period : ''}`;
   }
 
   protected transformVerbosity(description: string, useVerboseFormat: boolean) {
@@ -575,5 +576,9 @@ export class ExpressionDescriptor {
       description = description.replace(/\, ?$/, "");
     }
     return description;
+  }
+
+  private getPeriod(hour: number): string {
+    return hour >= 12 ? this.i18n.pm && this.i18n.pm() || 'PM' : this.i18n.am && this.i18n.am() || 'AM';
   }
 }

--- a/src/expressionDescriptor.ts
+++ b/src/expressionDescriptor.ts
@@ -544,7 +544,7 @@ export class ExpressionDescriptor {
 
   protected formatTime(hourExpression: string, minuteExpression: string, secondExpression: string) {
     let hour: number = parseInt(hourExpression);
-    let period: string = '';
+    let period: string = "";
     let setPeriodBeforeTime: boolean = false;
     if (!this.options.use24HourTimeFormat) {
       setPeriodBeforeTime = this.i18n.setPeriodBeforeTime && this.i18n.setPeriodBeforeTime();
@@ -558,14 +558,14 @@ export class ExpressionDescriptor {
     }
 
     const minute = minuteExpression;
-    let second: string = '';
+    let second: string = "";
     if (secondExpression) {
-      second = `:${('00' + secondExpression).substring(secondExpression.length)}`;
+      second = `:${("00" + secondExpression).substring(secondExpression.length)}`;
     }
 
-    return `${setPeriodBeforeTime ? period : ''}${('00' + hour.toString()).substring(hour.toString().length)}:${('00' + minute.toString()).substring(
+    return `${setPeriodBeforeTime ? period : ""}${("00" + hour.toString()).substring(hour.toString().length)}:${("00" + minute.toString()).substring(
       minute.toString().length
-    )}${second}${!setPeriodBeforeTime ? period : ''}`;
+    )}${second}${!setPeriodBeforeTime ? period : ""}`;
   }
 
   protected transformVerbosity(description: string, useVerboseFormat: boolean) {
@@ -579,6 +579,6 @@ export class ExpressionDescriptor {
   }
 
   private getPeriod(hour: number): string {
-    return hour >= 12 ? this.i18n.pm && this.i18n.pm() || 'PM' : this.i18n.am && this.i18n.am() || 'AM';
+    return hour >= 12 ? this.i18n.pm && this.i18n.pm() || "PM" : this.i18n.am && this.i18n.am() || "AM";
   }
 }

--- a/src/i18n/allLocales.ts
+++ b/src/i18n/allLocales.ts
@@ -4,6 +4,7 @@ export { de } from "./locales/de"; // German
 export { es } from "./locales/es"; // Spanish
 export { fr } from "./locales/fr"; // French
 export { it } from "./locales/it"; // Italian
+export { ko } from "./locales/ko"; // Korean
 export { nl } from "./locales/nl"; // Dutch
 export { nb } from "./locales/nb"; // Norwegian
 export { sv } from "./locales/sv"; // Swedish

--- a/src/i18n/locale.ts
+++ b/src/i18n/locale.ts
@@ -3,6 +3,9 @@ export interface Locale {
   // TODO: These locale translations would be a good use for ES6 template strings except we sometimes concatenate multiple transactions together before
   //       doing the actual template replacement.
 
+  setPeriodBeforeTime?(): boolean;
+  pm?(): string;
+  am?(): string;
   use24HourTimeFormatByDefault(): boolean;
   anErrorOccuredWhenGeneratingTheExpressionD(): string;
   everyMinute(): string;

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -1,0 +1,242 @@
+// Korean
+
+import { Locale } from "../locale";
+
+export class ko implements Locale {
+  public setPeriodBeforeTime(): boolean {
+    return true;
+  }
+
+  public pm(): string {
+    return "오후";
+  }
+
+  public am(): string {
+    return "오전";
+  }
+
+  public atX0SecondsPastTheMinuteGt20(): string {
+    return null;
+  }
+
+  public atX0MinutesPastTheHourGt20(): string {
+    return null;
+  }
+
+  public commaMonthX0ThroughMonthX1(): string {
+    return null;
+  }
+
+  public commaYearX0ThroughYearX1(): string {
+    return null;
+  }
+
+  public use24HourTimeFormatByDefault() {
+    return false;
+  }
+
+  public anErrorOccuredWhenGeneratingTheExpressionD() {
+    return "표현식 설명을 생성하는 중 오류가 발생했습니다. cron 표현식 구문을 확인하십시오.";
+  }
+
+  public everyMinute() {
+    return "1분마다";
+  }
+
+  public everyHour() {
+    return "1시간마다";
+  }
+
+  public atSpace() {
+    return "에서 ";
+  }
+
+  public everyMinuteBetweenX0AndX1() {
+    return "%s 및 %s 사이에 매 분";
+  }
+
+  public at() {
+    return "에서";
+  }
+
+  public spaceAnd() {
+    return " 및";
+  }
+
+  public everySecond() {
+    return "1초마다";
+  }
+
+  public everyX0Seconds() {
+    return "%s초마다";
+  }
+
+  public secondsX0ThroughX1PastTheMinute() {
+    return "정분 후 %s초에서 %s초까지";
+  }
+
+  public atX0SecondsPastTheMinute() {
+    return "정분 후 %s초에서";
+  }
+
+  public everyX0Minutes() {
+    return "%s분마다";
+  }
+
+  public minutesX0ThroughX1PastTheHour() {
+    return "정시 후 %s분에서 %s까지";
+  }
+
+  public atX0MinutesPastTheHour() {
+    return "정시 후 %s분에서";
+  }
+
+  public everyX0Hours() {
+    return "%s시간마다";
+  }
+
+  public betweenX0AndX1() {
+    return "%s에서 %s 사이";
+  }
+
+  public atX0() {
+    return "%s에서";
+  }
+
+  public commaEveryDay() {
+    return ", 매일";
+  }
+
+  public commaEveryX0DaysOfTheWeek() {
+    return ", 주 중 %s일마다";
+  }
+
+  public commaX0ThroughX1() {
+    return ", %s에서 %s가지";
+  }
+
+  public first() {
+    return "첫 번째";
+  }
+
+  public second() {
+    return "두 번째";
+  }
+
+  public third() {
+    return "세 번째";
+  }
+
+  public fourth() {
+    return "네 번째";
+  }
+
+  public fifth() {
+    return "다섯 번째";
+  }
+
+  public commaOnThe() {
+    return ", 해당 ";
+  }
+
+  public spaceX0OfTheMonth() {
+    return " 해당 월의 %s";
+  }
+
+  public lastDay() {
+    return "마지막 날";
+  }
+
+  public commaOnTheLastX0OfTheMonth() {
+    return ", 해당 월의 마지막 %s";
+  }
+
+  public commaOnlyOnX0() {
+    return ", %s에만";
+  }
+
+  public commaAndOnX0() {
+    return ", 및 %s에";
+  }
+
+  public commaEveryX0Months() {
+    return ", %s개월마다";
+  }
+
+  public commaOnlyInX0() {
+    return ", %s에서만";
+  }
+
+  public commaOnTheLastDayOfTheMonth() {
+    return ", 해당 월의 마지막 날에";
+  }
+
+  public commaOnTheLastWeekdayOfTheMonth() {
+    return ", 해당 월의 마지막 평일에";
+  }
+
+  public commaDaysBeforeTheLastDayOfTheMonth() {
+    return ", 해당 월의 마지막 날 %s일 전";
+  }
+
+  public firstWeekday() {
+    return "첫 번째 평일";
+  }
+
+  public weekdayNearestDayX0() {
+    return "평일 가장 가까운 날 %s";
+  }
+
+  public commaOnTheX0OfTheMonth() {
+    return ", 해당 월의 %s에";
+  }
+
+  public commaEveryX0Days() {
+    return ", %s일마다";
+  }
+
+  public commaBetweenDayX0AndX1OfTheMonth() {
+    return ", 해당 월의 %s일 및 %s일 사이";
+  }
+
+  public commaOnDayX0OfTheMonth() {
+    return ", 해당 월의 %s일에";
+  }
+
+  public commaEveryMinute() {
+    return ", 1분마다";
+  }
+
+  public commaEveryHour() {
+    return ", 1시간마다";
+  }
+
+  public commaEveryX0Years() {
+    return ", %s년마다";
+  }
+
+  public commaStartingX0() {
+    return ", %s부터";
+  }
+
+  public daysOfTheWeek() {
+    return ["일요일", "월요일", "화요일", "수요일", "목요일", "금요일", "토요일"];
+  }
+
+  public monthsOfTheYear() {
+    return [
+      "1월",
+      "2월",
+      "3월",
+      "4월",
+      "5월",
+      "6월",
+      "7월",
+      "8월",
+      "9월",
+      "10월",
+      "11월",
+      "12월"
+    ];
+  }
+}

--- a/test/i18n.ts
+++ b/test/i18n.ts
@@ -240,4 +240,10 @@ describe("i18n", function() {
       assert.equal(construe.toString(this.test.title, { locale: "sl" }), "Vsako minuto");
     });
   });
+
+  describe("ko", function() {
+    it("* * * * *", function() {
+      assert.equal(construe.toString(this.test.title, { locale: "ko" }), "1분마다");
+    });
+  });
 });


### PR DESCRIPTION
At Korean language PM/AM part of time expression goes at the beginning of the string: for example, PM hh:mm. Apart from that, it should be translated to Korean accordingly:
PM -> 오후
AM -> 오전

Extended interface of Locale with optional methods to expose flag controlling position of time period and translation of it:
- setPeriodBeforeTime
- am
- pm

 If they are not provided default values are used:
- false
- AM
- PM

So the changes are back-word compatible.

Translations are provided by native Korean speaker.