### PR TITLE
Update Finnish translation

### DIFF
--- a/src/i18n/locales/fi.ts
+++ b/src/i18n/locales/fi.ts
@@ -128,10 +128,10 @@ export class fi implements Locale {
     return "joka minuutti sekunttien %s - %s välillä";
   }
   spaceAnd(): string {
-    return "ja";
+    return " ja";
   }
   spaceAndSpace(): string {
-    return "ja";
+    return " ja ";
   }
   spaceX0OfTheMonth(): string {
     return "%s kuukaudessa";


### PR DESCRIPTION
The `spaceAnd()` and `spaceAndSpace()` functions are missing the spaces. I don't really know Finnish but when using your library in a personal project I run into this and checked with Google translate. 
I also compared it with the same functions in other languages and the spaces are indeed missing here.