### PR TITLE
Fix complex parsing for minutes

### DIFF
--- a/src/expressionDescriptor.ts
+++ b/src/expressionDescriptor.ts
@@ -461,7 +461,20 @@ export class ExpressionDescriptor {
       description = allDescription;
     } else if (!StringUtilities.containsAny(expression, ["/", "-", ","])) {
       description = StringUtilities.format(getDescriptionFormat(expression), getSingleItemDescription(expression));
-    } else if (expression.indexOf("/") > -1) {
+    } else if (expression.indexOf("/") > -1 && expression.indexOf(",") > -1) {
+      let segments: string[] = expression.split(",");
+      let segmentDescriptions: string[] = [];
+      for (let i = 0; i < segments.length; i++) {
+        segmentDescriptions.push(this.getSegmentDescription(segments[i],
+          allDescription,
+          getSingleItemDescription,
+          getIntervalDescriptionFormat,
+          getBetweenDescriptionFormat,
+          getDescriptionFormat
+        ));
+      }
+      description = segmentDescriptions.join(", ");
+    } else if (expression.indexOf("/") > -1 && expression.indexOf(",") == -1) {
       let segments: string[] = expression.split("/");
       description = StringUtilities.format(
         getIntervalDescriptionFormat(segments[1]),
@@ -491,7 +504,7 @@ export class ExpressionDescriptor {
 
         description += StringUtilities.format(this.i18n.commaStartingX0(), rangeItemDescription);
       }
-    } else if (expression.indexOf(",") > -1) {
+    } else if (expression.indexOf(",") > -1 && expression.indexOf("/") == -1) {
       let segments: string[] = expression.split(",");
 
       let descriptionContent: string = "";

--- a/test/cronParser.ts
+++ b/test/cronParser.ts
@@ -34,5 +34,9 @@ describe("CronParser", function() {
       assert.equal(new CronParser("30  2  *    *  *").parse().length, 7);
       assert.equal(new CronParser("* *  * *  * 2015").parse().length, 7);
     });
+
+    it("should parse cron with multiple commas", function () {
+      assert.equal(new CronParser("5-45/10,*/5,9 * * * *").parse().length, 7);
+    });
   });
 });

--- a/test/cronstrue.ts
+++ b/test/cronstrue.ts
@@ -460,7 +460,7 @@ describe("Cronstrue", function() {
     });
 
     it("0 */4,6 * * * ", function() {
-      assert.equal(construe.toString(this.test.title), "At 0 minutes past the hour, every 4,6 hours");
+      assert.equal(construe.toString(this.test.title), "At 0 minutes past the hour, every 4 hours, at 06:00 AM");
     });
 
     it("5 30 6,14,16 5 * *", function() {

--- a/test/cronstrue.ts
+++ b/test/cronstrue.ts
@@ -476,6 +476,13 @@ describe("Cronstrue", function() {
         "Every 3 minutes, minutes 0 through 20 past the hour, between 09:00 AM and 09:59 AM"
       );
     });
+
+    it("5-45/10,*/5,9 * * * *", function () {
+      assert.equal(
+        construe.toString(this.test.title),
+        "Every 10 minutes, minutes 5 through 45 past the hour, every 5 minutes, at 9 minutes past the hour"
+      );
+    });
   });
 
   describe("verbose", function() {


### PR DESCRIPTION
Fixes #124 

This is my first pass. Unfortunate, the requested wording was not compatible with established patterns in the library. 

- Requested: "Every 10 minutes from 5th minutes to 45th minute, every 5 minutes, at 9th minute"
- Actual: "Every 10 minutes, minutes 5 through 45 past the hour, every 5 minutes, at 9 minutes past the hour"

This was accomplished by splitting the expression on the comma and iteratively calling `getSegmentDescription` for each segment. So each segment is translated as it would be if it were the entire expression.

The downside to this approach is that "minutes 5 through 45 past the hour" is a little unclear. I am open to suggestions as to how to improve that (e.g. potentially joining the segments with semi-colons, "Every 10 minutes, minutes 5 through 45 past the hour; every 5 minutes; at 9 minutes past the hour")

---

This change also uncovered what I believe to be a mistake in a separate test, updated in a separate commit, for the expression `0 */4,6 * * *`.

Existing: "At 0 minutes past the hour, every 4,6 hours"
Updated: "At 0 minutes past the hour, every 4 hours, at 06:00 AM"

I believe the update is correct, based on the order of operations. This was confirmed by [crontab.guru](https://crontab.guru/#0_*/4,6_*_*_*).