### PR TITLE
Add an example of `verbose` usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ cronstrue.toString("* * * * *");
 cronstrue.toString("0 23 ? * MON-FRI");
 > "At 11:00 PM, Monday through Friday"
 
+cronstrue.toString("0 23 * * *", { verbose: true });
+> "At 11:00 PM, every day"
+
 cronstrue.toString("23 12 * * SUN#2");
 > "At 12:23 PM, on the second Sunday of the month"
 


### PR DESCRIPTION
Documenting `{ verbose: true }` feature would be useful, as said in https://github.com/bradymholt/cRonstrue/issues/128

See how rendered `README.md` looks like [here](https://github.com/Duwab/cRonstrue#usage)