### PR TITLE
Repeating hour string twice in Verbose mode

### DIFF
--- a/test/cronstrue.ts
+++ b/test/cronstrue.ts
@@ -15,6 +15,11 @@ describe("Cronstrue", function () {
     it("* * * * * (verbose)", function () {
       assert.equal(construe.toString("* * * * *", { verbose: true }), "Every minute, every hour, every day");
     });
+    
+    // this is not working as intended
+    it("0 * * * * (verbose)", function () {
+      assert.equal(construe.toString("0 * * * *", { verbose: true }), "Every hour, every day");
+    });
 
     it("*/1 * * * *", function () {
       assert.equal(construe.toString(this.test.title), "Every minute");


### PR DESCRIPTION
added a test for every hour. Currently it is returning "Every hour, every hour, every day"
(every hour is repeating twice)

### Repro steps:
1. Run `cronstrue.toString("0 * * * *", {verbose: true})`

### Expected Response
Every hour, every day

### Current Response
Every hour, every hour, every day