### PR TITLE
add support for monthStartIndexZero

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ cronstrue.toString("23 14 * * SUN#2", { use24HourTimeFormat: true });
 
 cronstrue.toString("* * * ? * 2-6/2", { dayOfWeekStartIndexZero: false });
 > "Every second, every 2 days of the week, Monday through Friday"
+
+cronstrue.toString("* * * 6-8 *", { monthStartIndexZero: true });
+> "Every minute, July through September"
 ```
 
 For more usage examples, including a demonstration of how cRonstrue can handle some very complex cron expressions, you can [reference the unit tests](https://github.com/bradymholt/cRonstrue/blob/master/test/cronstrue.ts).
@@ -90,6 +93,7 @@ An options object can be passed as the second parameter to `cronstrue.toString`.
 - **throwExceptionOnParseError: boolean** - If exception occurs when trying to parse expression and generate description, whether to throw or catch and output the Exception message as the description. (Default: true)
 - **verbose: boolean** - Whether to use a verbose description (Default: false)
 - **dayOfWeekStartIndexZero: boolean** - Whether to interpret cron expression DOW `1` as Sunday or Monday. (Default: true)
+- **monthStartIndexZero: boolean** - Wether to interpret January as `0` or `1`. (Default: false)
 - **use24HourTimeFormat: boolean** - If true, descriptions will use a [24-hour clock](https://en.wikipedia.org/wiki/24-hour_clock) (Default: false but some translations will default to true)
 - **locale: string** - The locale to use (Default: "en")
 

--- a/dist/cronParser.d.ts
+++ b/dist/cronParser.d.ts
@@ -1,7 +1,8 @@
 export declare class CronParser {
     expression: string;
     dayOfWeekStartIndexZero: boolean;
-    constructor(expression: string, dayOfWeekStartIndexZero?: boolean);
+    monthStartIndexZero: boolean;
+    constructor(expression: string, dayOfWeekStartIndexZero?: boolean, monthStartIndexZero?: boolean);
     parse(): string[];
     protected extractParts(expression: string): string[];
     protected normalize(expressionParts: string[]): void;

--- a/dist/expressionDescriptor.d.ts
+++ b/dist/expressionDescriptor.d.ts
@@ -10,7 +10,7 @@ export declare class ExpressionDescriptor {
     expressionParts: string[];
     options: Options;
     i18n: Locale;
-    static toString(expression: string, { throwExceptionOnParseError, verbose, dayOfWeekStartIndexZero, use24HourTimeFormat, locale, }?: Options): string;
+    static toString(expression: string, { throwExceptionOnParseError, verbose, dayOfWeekStartIndexZero, monthStartIndexZero, use24HourTimeFormat, locale, }?: Options): string;
     static initialize(localesLoader: LocaleLoader): void;
     constructor(expression: string, options: Options);
     protected getFullDescription(): string;

--- a/dist/options.d.ts
+++ b/dist/options.d.ts
@@ -2,6 +2,7 @@ export interface Options {
     throwExceptionOnParseError?: boolean;
     verbose?: boolean;
     dayOfWeekStartIndexZero?: boolean;
+    monthStartIndexZero?: boolean;
     use24HourTimeFormat?: boolean;
     locale?: string;
 }

--- a/dist/rangeValidator.d.ts
+++ b/dist/rangeValidator.d.ts
@@ -3,6 +3,6 @@ export default class RangeValidator {
     static minuteRange(parse: string): void;
     static hourRange(parse: string): void;
     static dayOfMonthRange(parse: string): void;
-    static monthRange(parse: string): void;
+    static monthRange(parse: string, monthStartIndexZero: boolean): void;
     static dayOfWeekRange(parse: string, dayOfWeekStartIndexZero: boolean): void;
 }

--- a/src/cronParser.ts
+++ b/src/cronParser.ts
@@ -174,9 +174,7 @@ export class CronParser {
 
       if (this.monthStartIndexZero) {
         // if monthStartIndexZero==true, we will shift month number up so that JAN=1 and DEC=12
-        console.log(dowDigits)
         dowDigitsAdjusted = (parseInt(dowDigits) + 1).toString();
-        console.log(dowDigitsAdjusted)
       }
 
       return t.replace(dowDigits, dowDigitsAdjusted);

--- a/src/expressionDescriptor.ts
+++ b/src/expressionDescriptor.ts
@@ -23,6 +23,7 @@ export class ExpressionDescriptor {
    *         casingType = CasingTypeEnum.Sentence,
    *         verbose = false,
    *         dayOfWeekStartIndexZero = true,
+   *         monthStartIndexZero = false,
    *         use24HourTimeFormat = false,
    *         locale = 'en'
    *     }={}]
@@ -34,6 +35,7 @@ export class ExpressionDescriptor {
       throwExceptionOnParseError = true,
       verbose = false,
       dayOfWeekStartIndexZero = true,
+      monthStartIndexZero = false,
       use24HourTimeFormat,
       locale = "en",
     }: Options = {}
@@ -45,6 +47,7 @@ export class ExpressionDescriptor {
       throwExceptionOnParseError: throwExceptionOnParseError,
       verbose: verbose,
       dayOfWeekStartIndexZero: dayOfWeekStartIndexZero,
+      monthStartIndexZero: monthStartIndexZero,
       use24HourTimeFormat: use24HourTimeFormat,
       locale: locale,
     };
@@ -83,7 +86,7 @@ export class ExpressionDescriptor {
     let description = "";
 
     try {
-      let parser = new CronParser(this.expression, this.options.dayOfWeekStartIndexZero);
+      let parser = new CronParser(this.expression, this.options.dayOfWeekStartIndexZero, this.options.monthStartIndexZero);
       this.expressionParts = parser.parse();
       var timeSegment = this.getTimeOfDayDescription();
       var dayOfMonthDesc = this.getDayOfMonthDescription();
@@ -203,8 +206,8 @@ export class ExpressionDescriptor {
         return s == "0"
           ? ""
           : parseInt(s) < 20
-          ? this.i18n.atX0SecondsPastTheMinute()
-          : this.i18n.atX0SecondsPastTheMinuteGt20() || this.i18n.atX0SecondsPastTheMinute();
+            ? this.i18n.atX0SecondsPastTheMinute()
+            : this.i18n.atX0SecondsPastTheMinuteGt20() || this.i18n.atX0SecondsPastTheMinute();
       }
     );
 
@@ -231,8 +234,8 @@ export class ExpressionDescriptor {
           return s == "0" && hourExpression.indexOf("/") == -1 && secondsExpression == ""
             ? this.i18n.everyHour()
             : parseInt(s) < 20
-            ? this.i18n.atX0MinutesPastTheHour()
-            : this.i18n.atX0MinutesPastTheHourGt20() || this.i18n.atX0MinutesPastTheHour();
+              ? this.i18n.atX0MinutesPastTheHour()
+              : this.i18n.atX0MinutesPastTheHourGt20() || this.i18n.atX0MinutesPastTheHour();
         } catch (e) {
           return this.i18n.atX0MinutesPastTheHour();
         }
@@ -408,8 +411,8 @@ export class ExpressionDescriptor {
                 return s == "L"
                   ? this.i18n.lastDay()
                   : this.i18n.dayX0
-                  ? StringUtilities.format(this.i18n.dayX0(), s)
-                  : s;
+                    ? StringUtilities.format(this.i18n.dayX0(), s)
+                    : s;
               },
               (s) => {
                 return s == "1" ? this.i18n.commaEveryDay() : this.i18n.commaEveryX0Days();

--- a/src/options.ts
+++ b/src/options.ts
@@ -2,6 +2,7 @@ export interface Options {
   throwExceptionOnParseError?: boolean;
   verbose?: boolean;
   dayOfWeekStartIndexZero?: boolean;
+  monthStartIndexZero?: boolean;
   use24HourTimeFormat?: boolean;
   locale?: string;
 }

--- a/src/rangeValidator.ts
+++ b/src/rangeValidator.ts
@@ -45,12 +45,15 @@ export default class RangeValidator {
     }
   }
 
-  static monthRange(parse: string) {
+  static monthRange(parse: string, monthStartIndexZero: boolean) {
     const parsed = parse.split(',');
     for (let i = 0; i < parsed.length; i++) {
       if (!isNaN(parseInt(parsed[i], 10))) {
         const month = parseInt(parsed[i], 10);
-        assert(month >= 1 && month <= 12, 'month part must be >= 1 and <= 12');
+        assert(
+          month >= 1 && month <= 12,
+          monthStartIndexZero ? 'month part must be >= 0 and <= 11' : 'month part must be >= 1 and <= 12'
+        );
       }
     }
   }

--- a/test/cronstrue.ts
+++ b/test/cronstrue.ts
@@ -319,6 +319,43 @@ describe("Cronstrue", function () {
     });
   });
 
+  describe("monthStartIndexZero=true", function () {
+    it("* * * 7 *", function () {
+      assert.equal(
+        construe.toString(this.test.title, { monthStartIndexZero: true }),
+        "Every minute, only in August"
+      );
+    });
+
+    it("30 * * 6-8 *", function () {
+      assert.equal(
+        construe.toString(this.test.title, { monthStartIndexZero: true }),
+        "At 30 minutes past the hour, July through September"
+      );
+    });
+
+    it("30 * * 1-10/2 *", function () {
+      assert.equal(
+        construe.toString(this.test.title, { monthStartIndexZero: true }),
+        "At 30 minutes past the hour, every 2 months, February through November"
+      );
+    });
+
+    it("30 * * 4,5,6 *", function () {
+      assert.equal(
+        construe.toString(this.test.title, { monthStartIndexZero: true }),
+        "At 30 minutes past the hour, only in May, June, and July"
+      );
+    });
+
+    it("30 * * JAN *", function () {
+      assert.equal(
+        construe.toString(this.test.title, { monthStartIndexZero: true }),
+        "At 30 minutes past the hour, only in January"
+      );
+    });
+  });
+
   describe("non-trivial expressions", function () {
     it("*/5 15 * * MON-FRI", function () {
       assert.equal(
@@ -547,8 +584,12 @@ describe("Cronstrue", function () {
 
     it('month out of range', function () {
       assert.throws(function () {
-        construe.toString("0 0 0 1 13 *");
+        construe.toString("0 0 0 1 13 *", { monthStartIndexZero: false });
       }, "month part must be >= 1 and <= 12")
+
+      assert.throws(function () {
+        construe.toString("0 0 0 1 13 *", { monthStartIndexZero: true });
+      }, "month part must be >= 0 and <= 11")
     });
 
     it('dayOfWeek out of range', function () {


### PR DESCRIPTION
Fixes #209

This PR will add support for `monthStartIndexZero`. By default this value will be set to false i.e JAN=1 and DEC=12. If it is set to `true` then JAN=0 and DEC=11.

This code pretty much copies `dayOfWeekStartIndexZero` with a small difference in the regex which now has `\d{1,2}` as number of digits in a month can be 1 or 2.

I also added test for some happy case and for validation.