### PR TITLE
Corrected packaging of locales to import base module and updated README (Fixes #230)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ cronstrue.toString("*/5 * * * *");
 Again, you can either require the full package with all i18n locales, or hand-pick them after imporing the base library.
 
 ```html
-<script src="https://unpkg.com/cronstrue@latest/cronstrue-i18n.min.js.js" async></script>
+<script src="https://unpkg.com/cronstrue@latest/cronstrue-i18n.min.js" async></script>
 <!-- Or -->
-<script src="https://unpkg.com/cronstrue@latest/cronstrue.min.js.js" async></script>
+<script src="https://unpkg.com/cronstrue@latest/cronstrue.min.js" async></script>
 <script src="https://unpkg.com/cronstrue@latest/locales/es.min.js" async></script>
 <script>
   cronstrue.toString("*/5 * * * *");

--- a/README.md
+++ b/README.md
@@ -99,7 +99,26 @@ An options object can be passed as the second parameter to `cronstrue.toString`.
 
 ## i18n
 
-To use the i18n support cRonstrue provides, you can import a specific locale and then call `toString()`. For example, for the es (Spanish) locale:
+cRonstrue provides a few ways to use i18n, depending on your situation.
+
+1. Use the packaged library that contains the locale translations.  
+Once you do this, you can pass the name of a supported locale as an option to  `cronstrue.toString()`.  
+For example, for the es (Spanish) locale, you would use: `cronstrue.toString("* * * * *", { locale: "es" });`.  
+
+```js
+var cronstrue = require('cronstrue/i18n');
+cronstrue.toString("*/5 * * * *", { locale: "fr" });
+```
+
+2. Import the specific locales you want:  
+
+```js
+var cronstrue = require('cronstrue');
+require('cronstrue/locales/fr');
+cronstrue.toString("*/5 * * * *", { locale: "fr" });
+```
+
+3. Directly import the locale and call its `toString`. For example, for the es (Spanish) locale:
 
 ```js
 import cronstrue from 'cronstrue/locales/es';
@@ -108,22 +127,16 @@ cronstrue.toString("*/5 * * * *");
 
 ### Browser
 
-A locale file from the `/locales` folder in the npm package should be served to the browser.
+Again, you can either require the full package with all i18n locales, or hand-pick them after imporing the base library.
 
 ```html
+<script src="https://unpkg.com/cronstrue@latest/cronstrue-i18n.min.js.js" async></script>
+<!-- Or -->
+<script src="https://unpkg.com/cronstrue@latest/cronstrue.min.js.js" async></script>
 <script src="https://unpkg.com/cronstrue@latest/locales/es.min.js" async></script>
 <script>
   cronstrue.toString("*/5 * * * *");
 </script>
-```
-
-### All Locales
-
-Alternatively you can import all locales and then pass in the `locale` option:
-
-```js
-import cronstrue from 'cronstrue/i18n';
-cronstrue.toString("*/5 * * * *", { locale: "es" });
 ```
 
 ## Frequently Asked Questions

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,7 +46,7 @@ module.exports = [
       minimize: true,
       minimizer: [
         new TerserJsPlugin({
-          include: /\.min\.js$|i18n\/locales/,
+          include: /\.min\.js$/,
         }),
       ],
     },
@@ -65,6 +65,9 @@ module.exports = [
     resolve: {
       extensions: [".js", ".ts"],
     },
+    externals: {
+      cronstrue: "cronstrue",
+    },
     module: {
       rules: [
         {
@@ -75,14 +78,10 @@ module.exports = [
               let localeCode = resourcePath.match(/i18n[\/\\]locales[\/\\]([a-zA-Z_]+)\.ts$/)[1];
               source = `\
 ${source}
-import { ExpressionDescriptor } from "../../expressionDescriptor";
-ExpressionDescriptor.initialize({
-  load(availableLocales) {
-    availableLocales["${localeCode}"] = new ${localeCode}();
-  }
-}, "${localeCode}");
-export default ExpressionDescriptor;
-let toString = ExpressionDescriptor.toString;
+import Cronstrue from \"cronstrue\";
+Cronstrue.locales["${localeCode}"] = new ${localeCode}();
+const toString = Cronstrue.toString;
+export default Cronstrue;
 export { toString };
 `;
               return source;
@@ -93,6 +92,14 @@ export { toString };
           test: /\.ts$/,
           loader: "ts-loader",
         },
+      ],
+    },
+    optimization: {
+      minimize: true,
+      minimizer: [
+        new TerserJsPlugin({
+          include: /\.min\.js$/,
+        }),
       ],
     },
     resolveLoader: {


### PR DESCRIPTION
This PR corrects a few problems that happened due to #230:

1. Minification did not work as expected - everything was minified instead only `.min` files.
2. All single locale files contains the whole cronstrue code. Importing `es` + `fr` would result in twice the size, hence the whole split that was done in the first place did not mean anything size-wise.
3. Updated README to showcase all situations