### PR TITLE
Add cronstrue binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,23 @@ cronstrue.toString("* * * 6-8 *", { monthStartIndexZero: true });
 
 For more usage examples, including a demonstration of how cRonstrue can handle some very complex cron expressions, you can [reference the unit tests](https://github.com/bradymholt/cRonstrue/blob/master/test/cronstrue.ts).
 
+### CLI Usage
+
+```sh
+$ npm install -g cronstrue
+
+$ cronstrue 1 2 3 4 5
+At 02:01 AM, on day 3 of the month, and on Friday, only in April
+
+$ cronstrue 1 2 3
+Error: too few arguments (3): 1 2 3
+Usage (5 args): cronstrue minute hour day-of-month month day-of-week
+or
+Usage (6 args): cronstrue second minute hour day-of-month month day-of-week
+or
+Usage (7 args): cronstrue second minute hour day-of-month month day-of-week year
+```
+
 ## Options
 
 An options object can be passed as the second parameter to `cronstrue.toString`.  The following options are available:

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+const cronstrue = require('../dist/cronstrue');
+
+function usage() {
+  console.error("Usage (5 args): cronstrue minute hour day-of-month month day-of-week");
+  console.error("or")
+  console.error("Usage (6 args): cronstrue second minute hour day-of-month month day-of-week");
+  console.error("or")
+  console.error("Usage (7 args): cronstrue second minute hour day-of-month month day-of-week year");
+}
+
+const args = process.argv.slice(2).join(" ");
+const argCount = args.trim().split(/\s+/).length;
+if (argCount < 5) {
+  console.error(`Error: too few arguments (${argCount}): ${args}`);
+  usage()
+  process.exit(1);
+}
+
+if (argCount > 7) {
+  console.error(`Error: too many arguments (${argCount}): ${args}`);
+  usage();
+  process.exit(2);
+}
+console.log(cronstrue.toString(args));

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "cron schedule"
   ],
   "main": "dist/cronstrue.js",
+  "bin": {
+    "cronstrue": "bin/cli.js"
+  },
   "typings": "dist/cronstrue.d.ts",
   "files": [
     "dist/",


### PR DESCRIPTION
```
$ npm install -g cronstrue

$ cronstrue 1 2 3 4 5
At 02:01 AM, on day 3 of the month, and on Friday, only in April

$ cronstrue 1 2 3
Error: too few arguments (3): 1 2 3
Usage (5 args): cronstrue minute hour day-of-month month day-of-week
or
Usage (6 args): cronstrue second minute hour day-of-month month day-of-week
or
Usage (7 args): cronstrue second minute hour day-of-month month day-of-week year
```