### PR TITLE
Fix ru locale

### DIFF
--- a/src/expressionDescriptor.ts
+++ b/src/expressionDescriptor.ts
@@ -209,7 +209,7 @@ export class ExpressionDescriptor {
         return s;
       },
       (s) => {
-        return StringUtilities.format(this.i18n.everyX0Seconds(), s);
+        return StringUtilities.format(this.i18n.everyX0Seconds(s), s);
       },
       (s) => {
         return this.i18n.secondsX0ThroughX1PastTheMinute();
@@ -218,8 +218,8 @@ export class ExpressionDescriptor {
         return s == "0"
           ? ""
           : parseInt(s) < 20
-          ? this.i18n.atX0SecondsPastTheMinute()
-          : this.i18n.atX0SecondsPastTheMinuteGt20() || this.i18n.atX0SecondsPastTheMinute();
+          ? this.i18n.atX0SecondsPastTheMinute(s)
+          : this.i18n.atX0SecondsPastTheMinuteGt20() || this.i18n.atX0SecondsPastTheMinute(s);
       }
     );
 
@@ -236,7 +236,7 @@ export class ExpressionDescriptor {
         return s;
       },
       (s) => {
-        return StringUtilities.format(this.i18n.everyX0Minutes(), s);
+        return StringUtilities.format(this.i18n.everyX0Minutes(s), s);
       },
       (s) => {
         return this.i18n.minutesX0ThroughX1PastTheHour();
@@ -246,10 +246,10 @@ export class ExpressionDescriptor {
           return s == "0" && hourExpression.indexOf("/") == -1 && secondsExpression == ""
             ? this.i18n.everyHour()
             : parseInt(s) < 20
-            ? this.i18n.atX0MinutesPastTheHour()
-            : this.i18n.atX0MinutesPastTheHourGt20() || this.i18n.atX0MinutesPastTheHour();
+            ? this.i18n.atX0MinutesPastTheHour(s)
+            : this.i18n.atX0MinutesPastTheHourGt20() || this.i18n.atX0MinutesPastTheHour(s);
         } catch (e) {
-          return this.i18n.atX0MinutesPastTheHour();
+          return this.i18n.atX0MinutesPastTheHour(s);
         }
       }
     );
@@ -266,7 +266,7 @@ export class ExpressionDescriptor {
         return this.formatTime(s, "0", "");
       },
       (s) => {
-        return StringUtilities.format(this.i18n.everyX0Hours(), s);
+        return StringUtilities.format(this.i18n.everyX0Hours(s), s);
       },
       (s) => {
         return this.i18n.betweenX0AndX1();
@@ -281,7 +281,10 @@ export class ExpressionDescriptor {
       const atTheHourMatches = Array.from(description.matchAll(/:00/g));
       if (atTheHourMatches.length > 1) {
         const lastAtTheHourMatchIndex = atTheHourMatches[atTheHourMatches.length - 1].index;
-        description = description.substring(0, lastAtTheHourMatchIndex) + ":59" + description.substring(lastAtTheHourMatchIndex! + 3);
+        description =
+          description.substring(0, lastAtTheHourMatchIndex) +
+          ":59" +
+          description.substring(lastAtTheHourMatchIndex! + 3);
       }
     }
 
@@ -301,7 +304,7 @@ export class ExpressionDescriptor {
       description = this.getSegmentDescription(
         this.expressionParts[5],
         this.i18n.commaEveryDay(),
-        (s) => {
+        (s, form) => {
           let exp: string = s;
           if (s.indexOf("#") > -1) {
             exp = s.substr(0, s.indexOf("#"));
@@ -309,51 +312,59 @@ export class ExpressionDescriptor {
             exp = exp.replace("L", "");
           }
 
-          return daysOfWeekNames[parseInt(exp)];
+          return this.i18n.daysOfTheWeekInCase
+            ? this.i18n.daysOfTheWeekInCase(form)[parseInt(exp)]
+            : daysOfWeekNames[parseInt(exp)];
         },
         (s) => {
           if (parseInt(s) == 1) {
             // rather than "every 1 days" just return empty string
             return "";
           } else {
-            return StringUtilities.format(this.i18n.commaEveryX0DaysOfTheWeek(), s);
+            return StringUtilities.format(this.i18n.commaEveryX0DaysOfTheWeek(s), s);
           }
         },
         (s) => {
           // If both DOM and DOW are specified, the cron will execute at either time.
+          const beginFrom = s.substring(0, s.indexOf("-"));
+
           const domSpecified = this.expressionParts[3] != "*";
-          return domSpecified ? this.i18n.commaAndX0ThroughX1() : this.i18n.commaX0ThroughX1();
+          return domSpecified ? this.i18n.commaAndX0ThroughX1(beginFrom) : this.i18n.commaX0ThroughX1(beginFrom);
         },
         (s) => {
           let format: string | null = null;
           if (s.indexOf("#") > -1) {
             let dayOfWeekOfMonthNumber: string = s.substring(s.indexOf("#") + 1);
+            let dayOfWeekNumber = s.substring(0, s.indexOf("#"));
             let dayOfWeekOfMonthDescription: string | null = null;
             switch (dayOfWeekOfMonthNumber) {
               case "1":
-                dayOfWeekOfMonthDescription = this.i18n.first();
+                dayOfWeekOfMonthDescription = this.i18n.first(dayOfWeekNumber);
                 break;
               case "2":
-                dayOfWeekOfMonthDescription = this.i18n.second();
+                dayOfWeekOfMonthDescription = this.i18n.second(dayOfWeekNumber);
                 break;
               case "3":
-                dayOfWeekOfMonthDescription = this.i18n.third();
+                dayOfWeekOfMonthDescription = this.i18n.third(dayOfWeekNumber);
                 break;
               case "4":
-                dayOfWeekOfMonthDescription = this.i18n.fourth();
+                dayOfWeekOfMonthDescription = this.i18n.fourth(dayOfWeekNumber);
                 break;
               case "5":
-                dayOfWeekOfMonthDescription = this.i18n.fifth();
+                dayOfWeekOfMonthDescription = this.i18n.fifth(dayOfWeekNumber);
                 break;
             }
 
-            format = this.i18n.commaOnThe() + dayOfWeekOfMonthDescription + this.i18n.spaceX0OfTheMonth();
+            format =
+              this.i18n.commaOnThe(dayOfWeekOfMonthNumber) +
+              dayOfWeekOfMonthDescription +
+              this.i18n.spaceX0OfTheMonth();
           } else if (s.indexOf("L") > -1) {
-            format = this.i18n.commaOnTheLastX0OfTheMonth();
+            format = this.i18n.commaOnTheLastX0OfTheMonth(s.replace("L", ""));
           } else {
             // If both DOM and DOW are specified, the cron will execute at either time.
             const domSpecified = this.expressionParts[3] != "*";
-            format = domSpecified ? this.i18n.commaAndOnX0() : this.i18n.commaOnlyOnX0();
+            format = domSpecified ? this.i18n.commaAndOnX0() : this.i18n.commaOnlyOnX0(s);
           }
 
           return format;
@@ -370,8 +381,10 @@ export class ExpressionDescriptor {
     let description: string | null = this.getSegmentDescription(
       this.expressionParts[4],
       "",
-      (s) => {
-        return monthNames[parseInt(s) - 1];
+      (s, form) => {
+        return form && this.i18n.monthsOfTheYearInCase
+          ? this.i18n.monthsOfTheYearInCase(form)[parseInt(s) - 1]
+          : monthNames[parseInt(s) - 1];
       },
       (s) => {
         //
@@ -379,7 +392,7 @@ export class ExpressionDescriptor {
           // rather than "every 1 months" just return empty string
           return "";
         } else {
-          return StringUtilities.format(this.i18n.commaEveryX0Months(), s);
+          return StringUtilities.format(this.i18n.commaEveryX0Months(s), s);
         }
       },
       (s) => {
@@ -405,8 +418,8 @@ export class ExpressionDescriptor {
       case "LW":
         description = this.i18n.commaOnTheLastWeekdayOfTheMonth();
         break;
-      default:
-        let weekDayNumberMatches = expression.match(/(\d{1,2}W)|(W\d{1,2})/); // i.e. 3W or W2
+      default: // i.e. 3W or W2
+        let weekDayNumberMatches = expression.match(/(\d{1,2}W)|(W\d{1,2})/);
         if (weekDayNumberMatches) {
           let dayNumber: number = parseInt(weekDayNumberMatches[0].replace("W", ""));
           let dayString: string =
@@ -421,7 +434,7 @@ export class ExpressionDescriptor {
           let lastDayOffSetMatches = expression.match(/L-(\d{1,2})/);
           if (lastDayOffSetMatches) {
             let offSetDays = lastDayOffSetMatches[1];
-            description = StringUtilities.format(this.i18n.commaDaysBeforeTheLastDayOfTheMonth(), offSetDays);
+            description = StringUtilities.format(this.i18n.commaDaysBeforeTheLastDayOfTheMonth(offSetDays), offSetDays);
             break;
           } else if (expression == "*" && this.expressionParts[5] != "*") {
             // * dayOfMonth and dayOfWeek specified so use dayOfWeek verbiage instead
@@ -438,13 +451,13 @@ export class ExpressionDescriptor {
                   : s;
               },
               (s) => {
-                return s == "1" ? this.i18n.commaEveryDay() : this.i18n.commaEveryX0Days();
+                return s == "1" ? this.i18n.commaEveryDay() : this.i18n.commaEveryX0Days(s);
               },
               (s) => {
-                return this.i18n.commaBetweenDayX0AndX1OfTheMonth();
+                return this.i18n.commaBetweenDayX0AndX1OfTheMonth(s);
               },
               (s) => {
-                return this.i18n.commaOnDayX0OfTheMonth();
+                return this.i18n.commaOnDayX0OfTheMonth(s);
               }
             );
           }
@@ -463,7 +476,7 @@ export class ExpressionDescriptor {
         return /^\d+$/.test(s) ? new Date(parseInt(s), 1).getFullYear().toString() : s;
       },
       (s) => {
-        return StringUtilities.format(this.i18n.commaEveryX0Years(), s);
+        return StringUtilities.format(this.i18n.commaEveryX0Years(s), s);
       },
       (s) => {
         return this.i18n.commaYearX0ThroughYearX1() || this.i18n.commaX0ThroughX1();
@@ -479,7 +492,7 @@ export class ExpressionDescriptor {
   protected getSegmentDescription(
     expression: string,
     allDescription: string,
-    getSingleItemDescription: (t: string) => string,
+    getSingleItemDescription: (t: string, form?: number) => string,
     getIncrementDescriptionFormat: (t: string) => string,
     getRangeDescriptionFormat: (t: string) => string,
     getDescriptionFormat: (t: string) => string
@@ -601,12 +614,12 @@ export class ExpressionDescriptor {
   protected generateRangeSegmentDescription(
     rangeExpression: string,
     getRangeDescriptionFormat: (t: string) => string,
-    getSingleItemDescription: (t: string) => string
+    getSingleItemDescription: (t: string, form?: number) => string
   ): string {
     let description: string = "";
     let rangeSegments: string[] = rangeExpression.split("-");
-    let rangeSegment1Description: string = getSingleItemDescription(rangeSegments[0]);
-    let rangeSegment2Description: string = getSingleItemDescription(rangeSegments[1]);
+    let rangeSegment1Description: string = getSingleItemDescription(rangeSegments[0], 1);
+    let rangeSegment2Description: string = getSingleItemDescription(rangeSegments[1], 2);
     let rangeDescriptionFormat = getRangeDescriptionFormat(rangeExpression);
     description += StringUtilities.format(rangeDescriptionFormat, rangeSegment1Description, rangeSegment2Description);
 

--- a/src/i18n/locale.ts
+++ b/src/i18n/locale.ts
@@ -15,50 +15,60 @@ export interface Locale {
   at(): string;
   spaceAnd(): string;
   everySecond(): string;
-  everyX0Seconds(): string;
+  everyX0Seconds(s?: string): string;
   secondsX0ThroughX1PastTheMinute(): string;
-  atX0SecondsPastTheMinute(): string;
-  atX0SecondsPastTheMinuteGt20(): string|null; // optional
-  everyX0Minutes(): string;
+  atX0SecondsPastTheMinute(s?: string): string;
+  atX0SecondsPastTheMinuteGt20(): string | null; // optional
+  everyX0Minutes(s?: string): string;
   minutesX0ThroughX1PastTheHour(): string;
-  atX0MinutesPastTheHour(): string;
-  atX0MinutesPastTheHourGt20(): string|null; // optional
-  everyX0Hours(): string;
+  atX0MinutesPastTheHour(s?: string): string;
+  atX0MinutesPastTheHourGt20(): string | null; // optional
+  everyX0Hours(s?: string): string;
   betweenX0AndX1(): string;
   atX0(): string;
   commaEveryDay(): string;
-  commaEveryX0DaysOfTheWeek(): string;
-  commaX0ThroughX1(): string;
-  commaAndX0ThroughX1(): string;
-  commaMonthX0ThroughMonthX1(): string|null; // optional
-  commaYearX0ThroughYearX1(): string|null; // optional
-  first(): string;
-  second(): string;
-  third(): string;
-  fourth(): string;
-  fifth(): string;
-  commaOnThe(): string;
+  commaEveryX0DaysOfTheWeek(s?: string): string;
+  commaX0ThroughX1(s?: string): string;
+  commaAndX0ThroughX1(s?: string): string;
+  commaMonthX0ThroughMonthX1(): string | null; // optional
+  commaYearX0ThroughYearX1(): string | null; // optional
+  first(s?: string): string;
+  second(s?: string): string;
+  third(s?: string): string;
+  fourth(s?: string): string;
+  fifth(s?: string): string;
+  commaOnThe(s?: string): string;
   spaceX0OfTheMonth(): string;
   lastDay(): string;
-  commaOnTheLastX0OfTheMonth(): string;
-  commaOnlyOnX0(): string;
+  commaOnTheLastX0OfTheMonth(s?: string): string;
+  commaOnlyOnX0(s?: string): string;
   commaAndOnX0(): string;
-  commaEveryX0Months(): string;
+  commaEveryX0Months(s?: string): string;
   commaOnlyInX0(): string;
   commaOnlyInMonthX0?(): string;
   commaOnlyInYearX0?(): string;
   commaOnTheLastDayOfTheMonth(): string;
   commaOnTheLastWeekdayOfTheMonth(): string;
-  commaDaysBeforeTheLastDayOfTheMonth(): string;
+  commaDaysBeforeTheLastDayOfTheMonth(s?: string): string;
   firstWeekday(): string;
   weekdayNearestDayX0(): string;
   commaOnTheX0OfTheMonth(): string;
-  commaEveryX0Days(): string;
-  commaBetweenDayX0AndX1OfTheMonth(): string;
-  commaOnDayX0OfTheMonth(): string;
-  commaEveryX0Years(): string;
+  commaEveryX0Days(s?: string): string;
+  commaBetweenDayX0AndX1OfTheMonth(s?: string): string;
+  commaOnDayX0OfTheMonth(s?: string): string;
+  commaEveryX0Years(s?: string): string;
   commaStartingX0(): string;
   dayX0?(): string;
   daysOfTheWeek(): string[];
+  /** If multiple forms are needed in "%s through %s"
+   * @param f 1 for "from", 2 for "through"
+   * @return {string[]} days of week
+   */
+  daysOfTheWeekInCase?(f?: number): string[];
   monthsOfTheYear(): string[];
+  /** If multiple forms are needed in "%s through %s"
+   * @param f 1 for "from", 2 for "through"
+   * @return {string[]} months of year
+   */
+  monthsOfTheYearInCase?(f?: number): string[];
 }

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -1,17 +1,29 @@
 // Russian
 
 import { Locale } from "../locale";
+
+const getPhraseByNumber = (str: string, words: Array<string>) => {
+  const number = Number(str);
+  return number
+    ? words[number % 100 > 4 && number % 100 < 20 ? 2 : [2, 0, 1, 1, 1, 2][number % 10 < 5 ? Math.abs(number) % 10 : 5]]
+    : words[2];
+};
+const getPhraseByDayOfWeek = (str: string, words: Array<string>) => {
+  const number = Number(str);
+  return number ? words[number === 0 ? 0 : number === 1 || number === 2 || number === 4 ? 1 : 2] : words[1];
+};
+
 export class ru implements Locale {
-  atX0SecondsPastTheMinuteGt20(): string|null {
+  atX0SecondsPastTheMinuteGt20(): string | null {
     return null;
   }
-  atX0MinutesPastTheHourGt20(): string|null {
+  atX0MinutesPastTheHourGt20(): string | null {
     return null;
   }
-  commaMonthX0ThroughMonthX1(): string|null {
+  commaMonthX0ThroughMonthX1(): string | null {
     return null;
   }
-  commaYearX0ThroughYearX1(): string|null {
+  commaYearX0ThroughYearX1(): string | null {
     return null;
   }
   use24HourTimeFormatByDefault() {
@@ -41,26 +53,26 @@ export class ru implements Locale {
   everySecond() {
     return "каждую секунду";
   }
-  everyX0Seconds() {
-    return "каждые %s секунд";
+  everyX0Seconds(s: string) {
+    return getPhraseByNumber(s, ["каждую %s секунду", "каждые %s секунды", "каждые %s секунд"]);
   }
   secondsX0ThroughX1PastTheMinute() {
     return "секунды с %s по %s";
   }
-  atX0SecondsPastTheMinute() {
-    return "в %s секунд";
+  atX0SecondsPastTheMinute(s: string) {
+    return getPhraseByNumber(s, ["в %s секунду", "в %s секунды", "в %s секунд"]);
   }
-  everyX0Minutes() {
-    return "каждые %s минут";
+  everyX0Minutes(s: string) {
+    return getPhraseByNumber(s, ["каждую %s минуту", "каждые %s минуты", "каждые %s минут"]);
   }
   minutesX0ThroughX1PastTheHour() {
     return "минуты с %s по %s";
   }
-  atX0MinutesPastTheHour() {
-    return "в %s минут";
+  atX0MinutesPastTheHour(s: string) {
+    return getPhraseByNumber(s, ["в %s минуту", "в %s минуты", "в %s минут"]);
   }
-  everyX0Hours() {
-    return "каждые %s часов";
+  everyX0Hours(s: string) {
+    return getPhraseByNumber(s, ["каждый %s час", "каждые %s часа", "каждые %s часов"]);
   }
   betweenX0AndX1() {
     return "с %s по %s";
@@ -71,32 +83,32 @@ export class ru implements Locale {
   commaEveryDay() {
     return ", каждый день";
   }
-  commaEveryX0DaysOfTheWeek() {
-    return ", каждые %s дней недели";
+  commaEveryX0DaysOfTheWeek(s: string) {
+    return getPhraseByNumber(s, ["", ", каждые %s дня недели", ", каждые %s дней недели"]);
   }
-  commaX0ThroughX1() {
-    return ", %s по %s";
+  commaX0ThroughX1(s: string) {
+    return s[0] == "2" || s[0] == "3" ? ", со %s по %s" : ", с %s по %s";
   }
-  commaAndX0ThroughX1() {
-    return ", и %s по %s";
+  commaAndX0ThroughX1(s: string) {
+    return s[0] == "2" || s[0] == "3" ? " и со %s по %s" : " и с %s по %s";
   }
-  first() {
-    return "первый";
+  first(s: string) {
+    return getPhraseByDayOfWeek(s, ["первое", "первый", "первую"]);
   }
-  second() {
-    return "второй";
+  second(s: string) {
+    return getPhraseByDayOfWeek(s, ["второе", "второй", "вторую"]);
   }
-  third() {
-    return "третий";
+  third(s: string) {
+    return getPhraseByDayOfWeek(s, ["третье", "третий", "третью"]);
   }
-  fourth() {
-    return "четвертый";
+  fourth(s: string) {
+    return getPhraseByDayOfWeek(s, ["четвертое", "четвертый", "четвертую"]);
   }
-  fifth() {
-    return "пятый";
+  fifth(s: string) {
+    return getPhraseByDayOfWeek(s, ["пятое", "пятый", "пятую"]);
   }
-  commaOnThe() {
-    return ", в ";
+  commaOnThe(s: string) {
+    return s === "2" ? ", во " : ", в ";
   }
   spaceX0OfTheMonth() {
     return " %s месяца";
@@ -104,17 +116,20 @@ export class ru implements Locale {
   lastDay() {
     return "последний день";
   }
-  commaOnTheLastX0OfTheMonth() {
-    return ", в последний %s месяца";
+  commaOnTheLastX0OfTheMonth(s: string) {
+    return getPhraseByDayOfWeek(s, [", в последнее %s месяца", ", в последний %s месяца", ", в последнюю %s месяца"]);
   }
-  commaOnlyOnX0() {
-    return ", только в %s";
+  commaOnlyOnX0(s: string) {
+    return s[0] === "2" ? ", только во %s" : ", только в %s";
   }
   commaAndOnX0() {
-    return ", и в %s";
+    return ", и %s";
   }
-  commaEveryX0Months() {
-    return ", каждые %s месяцев";
+  commaEveryX0Months(s: string) {
+    return getPhraseByNumber(s, ["", " каждые %s месяца", " каждые %s месяцев"]);
+  }
+  commaOnlyInMonthX0() {
+    return ", только %s";
   }
   commaOnlyInX0() {
     return ", только в %s";
@@ -125,35 +140,44 @@ export class ru implements Locale {
   commaOnTheLastWeekdayOfTheMonth() {
     return ", в последний будний день месяца";
   }
-  commaDaysBeforeTheLastDayOfTheMonth() {
-    return ", %s дней до последнего дня месяца";
+  commaDaysBeforeTheLastDayOfTheMonth(s: string) {
+    return getPhraseByNumber(s, [
+      ", за %s день до конца месяца",
+      ", за %s дня до конца месяца",
+      ", за %s дней до конца месяца",
+    ]);
   }
   firstWeekday() {
     return "первый будний день";
   }
   weekdayNearestDayX0() {
-    return "ближайший будний день к %s";
+    return "ближайший будний день к %s числу";
   }
   commaOnTheX0OfTheMonth() {
     return ", в %s месяца";
   }
-  commaEveryX0Days() {
-    return ", каждые %s дней";
+  commaEveryX0Days(s: string) {
+    return getPhraseByNumber(s, [", каждый %s день", ", каждые %s дня", ", каждые %s дней"]);
   }
-  commaBetweenDayX0AndX1OfTheMonth() {
-    return ", с %s по %s число месяца";
+  commaBetweenDayX0AndX1OfTheMonth(s: string) {
+    return s.substring(0, s.indexOf("-")) == "2" ? ", со %s по %s число месяца" : ", с %s по %s число месяца";
   }
-  commaOnDayX0OfTheMonth() {
-    return ", в %s число месяца";
+  commaOnDayX0OfTheMonth(s: string) {
+    return s[0] == "2" ? ", во %s число месяца" : ", в %s число месяца";
   }
-  commaEveryX0Years() {
-    return ", каждые %s лет";
+  commaEveryX0Years(s: string) {
+    return getPhraseByNumber(s, [", каждый %s год", ", каждые %s года", ", каждые %s лет"]);
   }
   commaStartingX0() {
     return ", начало %s";
   }
   daysOfTheWeek() {
     return ["воскресенье", "понедельник", "вторник", "среда", "четверг", "пятница", "суббота"];
+  }
+  daysOfTheWeekInCase(f: number = 2) {
+    return f == 1
+      ? ["воскресенья", "понедельника", "вторника", "среды", "четверга", "пятницы", "субботы"]
+      : ["воскресенье", "понедельник", "вторник", "среду", "четверг", "пятницу", "субботу"];
   }
   monthsOfTheYear() {
     return [
@@ -170,5 +194,23 @@ export class ru implements Locale {
       "ноябрь",
       "декабрь",
     ];
+  }
+  monthsOfTheYearInCase(f: number) {
+    return f == 1
+      ? [
+          "января",
+          "февраля",
+          "марта",
+          "апреля",
+          "мая",
+          "июня",
+          "июля",
+          "августа",
+          "сентября",
+          "октября",
+          "ноября",
+          "декабря",
+        ]
+      : this.monthsOfTheYear();
   }
 }

--- a/test/i18n.ts
+++ b/test/i18n.ts
@@ -204,7 +204,7 @@ describe("i18n", function () {
     it("*/5 15 * * MON-FRI", function () {
       assert.equal(
         cronstrue.toString(this.test?.title as string, { locale: "ru" }),
-        "Каждые 5 минут, с 15:00 по 15:59, понедельник по пятница"
+        "Каждые 5 минут, с 15:00 по 15:59, с понедельника по пятницу"
       );
     });
   });


### PR DESCRIPTION
Word formation is complex In Russian and other Slavic languages. For example, */21, */22, */25 (minutes) - кажд**ую** 21 мину**ту**, кажд**ые** 22 мину**ты**, кажд**ые** 25 мину**т**. Or "Sunday through Tuesday" is "**с** воскресенья по вторни**к**", but "Tuesday through Friday" is "**со** вторни**ка** по пятницу".
I have added optional arguments to some functions and use it in ru locale. It may be helpful for _be, uk_ and some other locales.