### PR TITLE
Fix multiple days of week outputs null

### DIFF
--- a/src/expressionDescriptor.ts
+++ b/src/expressionDescriptor.ts
@@ -307,14 +307,40 @@ export class ExpressionDescriptor {
         (s, form) => {
           let exp: string = s;
           if (s.indexOf("#") > -1) {
-            exp = s.substr(0, s.indexOf("#"));
+            exp = s.substring(0, s.indexOf("#"));
           } else if (s.indexOf("L") > -1) {
             exp = exp.replace("L", "");
           }
 
-          return this.i18n.daysOfTheWeekInCase
+          let description = this.i18n.daysOfTheWeekInCase
             ? this.i18n.daysOfTheWeekInCase(form)[parseInt(exp)]
             : daysOfWeekNames[parseInt(exp)];
+
+          if (s.indexOf("#") > -1) {
+            let dayOfWeekOfMonthDescription: string | null = null;
+            let dayOfWeekOfMonthNumber: string = s.substring(s.indexOf("#") + 1);
+            let dayOfWeekNumber = s.substring(0, s.indexOf("#"));
+            switch (dayOfWeekOfMonthNumber) {
+              case "1":
+                dayOfWeekOfMonthDescription = this.i18n.first(dayOfWeekNumber);
+                break;
+              case "2":
+                dayOfWeekOfMonthDescription = this.i18n.second(dayOfWeekNumber);
+                break;
+              case "3":
+                dayOfWeekOfMonthDescription = this.i18n.third(dayOfWeekNumber);
+                break;
+              case "4":
+                dayOfWeekOfMonthDescription = this.i18n.fourth(dayOfWeekNumber);
+                break;
+              case "5":
+                dayOfWeekOfMonthDescription = this.i18n.fifth(dayOfWeekNumber);
+                break;
+            }
+            description = dayOfWeekOfMonthDescription + " " + description;
+          }
+
+          return description;
         },
         (s) => {
           if (parseInt(s) == 1) {
@@ -335,30 +361,7 @@ export class ExpressionDescriptor {
           let format: string | null = null;
           if (s.indexOf("#") > -1) {
             let dayOfWeekOfMonthNumber: string = s.substring(s.indexOf("#") + 1);
-            let dayOfWeekNumber = s.substring(0, s.indexOf("#"));
-            let dayOfWeekOfMonthDescription: string | null = null;
-            switch (dayOfWeekOfMonthNumber) {
-              case "1":
-                dayOfWeekOfMonthDescription = this.i18n.first(dayOfWeekNumber);
-                break;
-              case "2":
-                dayOfWeekOfMonthDescription = this.i18n.second(dayOfWeekNumber);
-                break;
-              case "3":
-                dayOfWeekOfMonthDescription = this.i18n.third(dayOfWeekNumber);
-                break;
-              case "4":
-                dayOfWeekOfMonthDescription = this.i18n.fourth(dayOfWeekNumber);
-                break;
-              case "5":
-                dayOfWeekOfMonthDescription = this.i18n.fifth(dayOfWeekNumber);
-                break;
-            }
-
-            format =
-              this.i18n.commaOnThe(dayOfWeekOfMonthNumber) +
-              dayOfWeekOfMonthDescription +
-              this.i18n.spaceX0OfTheMonth();
+            format = this.i18n.commaOnThe(dayOfWeekOfMonthNumber).trim() + this.i18n.spaceX0OfTheMonth();
           } else if (s.indexOf("L") > -1) {
             format = this.i18n.commaOnTheLastX0OfTheMonth(s.replace("L", ""));
           } else {

--- a/test/cronstrue.ts
+++ b/test/cronstrue.ts
@@ -369,6 +369,10 @@ describe("Cronstrue", function () {
       assert.equal(cronstrue.toString(this.test?.title as string), "Every minute, on the third Monday of the month");
     });
 
+    it("* * * * MON#3,THU#1", function () {
+      assert.equal(cronstrue.toString(this.test?.title as string), "Every minute, on the third Monday and first Thursday of the month");
+    });
+
     it("5-10 * * * * *", function () {
       assert.equal(cronstrue.toString(this.test?.title as string), "Seconds 5 through 10 past the minute");
     });


### PR DESCRIPTION
fix #199

I have moved the code that adds numeric prefixes (first, second, etc) to the `getSingleItemDescription`. It was previously in the `getDescriptionFormat` and tried to find correct prefix for e.g. `#3,1#2`, because it took only the first weekday into consideration.

The code diff looks crazy, but if you take a closer look then you will se that I only moved the `switch` statement to another method and concatenated properly.

It seems to fix the problem and does not break any tests :-)