### PR TITLE
If string has a range in first interval don't render "de"

### DIFF
--- a/src/i18n/locales/pt_BR.ts
+++ b/src/i18n/locales/pt_BR.ts
@@ -56,11 +56,11 @@ export class pt_BR implements Locale {
   commaOnDayX0OfTheMonth() {
     return ", no dia %s do mês";
   }
-  commaOnlyInX0() {
-    return ", somente em %s";
+  commaOnlyInX0(s?: string) {
+    return s && s.length > 1 && s[1] === "-" ? "somente %s" : ", somente em %s";
   }
-  commaOnlyOnX0() {
-    return ", somente de %s";
+  commaOnlyOnX0(s?: string) {
+    return s && s.length > 1 && s[1] === "-" ? ", somente %s" : ", somente de %s";
   }
   commaAndOnX0() {
     return ", e de %s";

--- a/test/i18n.ts
+++ b/test/i18n.ts
@@ -156,7 +156,6 @@ describe("i18n", function () {
       );
     });
   });
-
   describe("pt_BR", function () {
     it("* * * * *", function () {
       assert.equal(cronstrue.toString(this.test?.title as string, { locale: "pt_BR" }), "A cada minuto");
@@ -168,7 +167,15 @@ describe("i18n", function () {
         "A cada 5 minutos, entre 03:00 PM e 03:59 PM, de segunda-feira a sexta-feira"
       );
     });
+
+    it("*/5 15 * * MON-FRI,SUN", function () {
+      assert.equal(
+        cronstrue.toString(this.test?.title as string, { locale: "pt_BR" }),
+        "A cada 5 minutos, entre 03:00 PM e 03:59 PM, somente de segunda-feira a sexta-feira e domingo"
+      );
+    });
   });
+
 
   describe("pt_PT", function () {
     it("* * * * *", function () {


### PR DESCRIPTION
This pull request addresses an issue where double occurrences of "de" were introduced during the conversion of certain cron expressions to text in the pt_BR locale. The proposed changes ensure that the double "de" is prevented, specifically when a range is present at the beginning of the string.

| expression | response | expected |
| ---- | --------- | ---------- |
| * * * 1-4,7 | somente de de segunda-feira a sexta-feira e domingo | somente de segunda-feira a sexta-feira e domingo|
| * * * 1-4,6 * | a cada dia, somente em de janeiro a abril e junho | a cada dia, somente de janeiro a abril e junho |