### PR TITLE
fix: wrong word when DOM and DOW both present (#272)

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -113,7 +113,7 @@ export class en implements Locale {
     return ", only on %s";
   }
   commaAndOnX0() {
-    return ", and on %s";
+    return ", or on %s";
   }
   commaEveryX0Months() {
     return ", every %s months";

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -113,7 +113,7 @@ export class en implements Locale {
     return ", only on %s";
   }
   commaAndOnX0() {
-    return ", or on %s";
+    return ", and on %s";
   }
   commaEveryX0Months() {
     return ", every %s months";

--- a/src/i18n/locales/zh_CN.ts
+++ b/src/i18n/locales/zh_CN.ts
@@ -123,7 +123,7 @@ export class zh_CN implements Locale {
     return ", 仅%s";
   }
   commaAndOnX0() {
-    return ", 并且为%s";
+    return ", 或者为%s";
   }
   commaEveryX0Months() {
     return ", 每隔 %s 个月";

--- a/src/i18n/locales/zh_TW.ts
+++ b/src/i18n/locales/zh_TW.ts
@@ -111,7 +111,7 @@ export class zh_TW implements Locale {
     return ", 僅在 %s";
   }
   commaAndOnX0() {
-    return ", 和 %s";
+    return ", 或 %s";
   }
   commaEveryX0Months() {
     return ", 每 %s 月";


### PR DESCRIPTION
As described in #272, when both DOM and DOW present, the default behavior of cron will schedule on both matches.

And this is also commented in the source code as: https://github.com/bradymholt/cRonstrue/blob/main/src/expressionDescriptor.ts#L388

So I changed the language to express the correct meaning.

Since I can only speak `zh` and `en`, I only did changes in these files:

* en.ts
* zh_CN.ts
* zh_TW.ts
