### PR TITLE
Fix some french mistakes

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -20,7 +20,7 @@ export class en implements Locale {
   }
 
   anErrorOccuredWhenGeneratingTheExpressionD() {
-    return "An error occured when generating the expression description.  Check the cron expression syntax.";
+    return "An error occurred when generating the expression description. Check the cron expression syntax.";
   }
   everyMinute() {
     return "every minute";

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -19,14 +19,14 @@ export class fr implements Locale {
     return true;
   }
 
+  anErrorOccuredWhenGeneratingTheExpressionD() {
+    return "Une erreur est survenue en générant la description de l'expression cron. Vérifiez sa syntaxe.";
+  }
   everyMinute() {
     return "toutes les minutes";
   }
   everyHour() {
     return "toutes les heures";
-  }
-  anErrorOccuredWhenGeneratingTheExpressionD() {
-    return "Une erreur est survenue en générant la description de l'expression cron. Vérifiez sa syntaxe.";
   }
   atSpace() {
     return "À ";
@@ -68,7 +68,7 @@ export class fr implements Locale {
     return "de %s à %s";
   }
   atX0() {
-    return "à %s";
+    return "%s";
   }
   commaEveryDay() {
     return ", tous les jours";
@@ -146,11 +146,15 @@ export class fr implements Locale {
     return ", du %s au %s du mois";
   }
   commaOnDayX0OfTheMonth() {
-    return ", le %s du mois";
+    return ", %s du mois";
+  }
+  commaEveryHour() {
+    return ", chaque heure";
   }
   commaEveryX0Years() {
     return ", tous les %s ans";
   }
+  // No longer used?
   commaDaysX0ThroughX1() {
     return ", du %s au %s";
   }

--- a/test/cronParser.ts
+++ b/test/cronParser.ts
@@ -1,7 +1,6 @@
-import 'mocha';
-import chai = require("chai");
+import "mocha";
+import { assert } from "chai";
 import { CronParser } from "../src/cronParser";
-let assert = chai.assert;
 
 describe("CronParser", function () {
   describe("parse", function () {
@@ -28,10 +27,10 @@ describe("CronParser", function () {
       }, `Expression contains invalid values: 'MO'`);
     });
 
-     it("does not allow unexpected characters or statements in any part", function () {
+    it("does not allow unexpected characters or statements in any part", function () {
       const maliciousStatement = "\nDROP\tDATABASE\tusers;";
 
-      for(let i = 0; i <= 6; i++) {
+      for (let i = 0; i <= 6; i++) {
         const cleanCronParts = ["*", "*", "*", "*", "*", "*", "*"];
         cleanCronParts[i] = maliciousStatement;
         const cronToTest = cleanCronParts.join(" ");

--- a/test/cronstrue.ts
+++ b/test/cronstrue.ts
@@ -1,7 +1,6 @@
 import "mocha";
-import chai = require("chai");
+import { assert } from "chai";
 import cronstrue from "../src/cronstrue";
-let assert = chai.assert;
 
 describe("Cronstrue", function () {
   describe("every", function () {
@@ -193,11 +192,11 @@ describe("Cronstrue", function () {
     });
 
     it("10 11 * * *", function () {
-      assert.equal(cronstrue.toString(this.test?.title as string, { verbose: true}), "At 11:10 AM, every day");
+      assert.equal(cronstrue.toString(this.test?.title as string, { verbose: true }), "At 11:10 AM, every day");
     });
 
     it("30 22 * * *", function () {
-      assert.equal(cronstrue.toString(this.test?.title as string, { use24HourTimeFormat: true}), "At 22:30");
+      assert.equal(cronstrue.toString(this.test?.title as string, { use24HourTimeFormat: true }), "At 22:30");
     });
 
     it("5 1 * * 1", function () {
@@ -805,7 +804,7 @@ describe("Cronstrue", function () {
     it("garbage expression with option (throwExceptionOnParseError = false)", function () {
       assert.equal(
         cronstrue.toString("garbage", { throwExceptionOnParseError: false }),
-        "An error occured when generating the expression description.  Check the cron expression syntax."
+        "An error occurred when generating the expression description. Check the cron expression syntax."
       );
     });
   });

--- a/test/i18n.ts
+++ b/test/i18n.ts
@@ -1,9 +1,6 @@
 import "mocha";
-
+import { assert } from "chai";
 import cronstrue from "../src/cronstrue-i18n";
-
-import chai = require("chai");
-let assert = chai.assert;
 
 describe("i18n", function () {
   describe("de", function () {

--- a/test/stringUtilities.ts
+++ b/test/stringUtilities.ts
@@ -1,7 +1,6 @@
-import 'mocha';
-import chai = require("chai");
+import "mocha";
+import { assert } from "chai";
 import { StringUtilities } from "../src/stringUtilities";
-let assert = chai.assert;
 
 describe("StringUtilities", function () {
   describe("format", function () {


### PR DESCRIPTION
Half a fix for #337, it does correct a few wrong things but I cannot find a way to satisfy both of these cases:
`à partir de 03:00` and `à partir de 3 du mois` as "à partir" is only declared once in the methods.

The reason is in french, "à partir" is correlated by the subject, when it's a specific period (for example a day like monday or a month), we say "à partir de".
When it's about a specific time / date (for example 3 january or "15" of the month), we say "à partir du".

As this project doesn't have something particular for any language, I kept "à partir de" as a general case, meaning `à partir de 3 du mois` is wrong.