### PR TITLE
Fix: Incorrect Multiple Range Hour Interpretation (#294)

### DIFF
--- a/test/cronstrue.ts
+++ b/test/cronstrue.ts
@@ -669,6 +669,20 @@ describe("Cronstrue", function () {
         "Every 10 minutes, minutes 5 through 45 past the hour, every 5 minutes, and at 9 minutes past the hour"
       );
     });
+
+    it("*/5 0-4,6-8 * * *", function () {
+      assert.equal(
+        cronstrue.toString(this.test?.title as string),
+        "Every 5 minutes, at 12:00 AM through 04:59 AM and 06:00 AM through 08:59 AM"
+      );
+    });
+
+    it("* 1-2,22-23 * * *", function () {
+      assert.equal(
+        cronstrue.toString(this.test?.title as string),
+        "Every minute, at 01:00 AM through 02:59 AM and 10:00 PM through 11:59 PM"
+      );
+    });
   });
 
   describe("@ expressions", function () {


### PR DESCRIPTION
This merge request addresses the issue described in #294, where multiple hour ranges in a cron expression were not being interpreted correctly. Specifically, the end of each hour range was incorrectly formatted as :00 instead of :59 for the last minute of the range.

All tests have been run and passed successfully after applying this fix. If the proposed solution does not align with your vision for the library or if you prefer a different approach, feel free to close this merge request or update it as you see fit. Thank you for maintaining this great library!