### PR TITLE
feat: add support for @ syntax expressions in CLI

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3,24 +3,41 @@
 const cronstrue = require('../dist/cronstrue');
 
 function usage() {
+  console.error("Usage: cronstrue \"<expression>\"");
+  console.error("  or");
   console.error("Usage (5 args): cronstrue minute hour day-of-month month day-of-week");
-  console.error("or")
+  console.error("  or");
   console.error("Usage (6 args): cronstrue second minute hour day-of-month month day-of-week");
-  console.error("or")
+  console.error("  or");
   console.error("Usage (7 args): cronstrue second minute hour day-of-month month day-of-week year");
+  console.error("");
+  console.error("Examples:");
+  console.error("  cronstrue \"*/5 * * * *\"");
+  console.error("  cronstrue \"@daily\"");
+  console.error("  cronstrue 0 0 * * 1");
 }
 
-const args = process.argv.slice(2).join(" ");
-const argCount = args.trim().split(/\s+/).length;
+const args = process.argv.slice(2);
+
+// Handle the case where a single argument is provided, which might be a complete cron expression or special @ syntax
+if (args.length === 1) {
+  console.log(cronstrue.toString(args[0]));
+  process.exit(0);
+}
+
+// Handle the 5-7 arguments case
+const expression = args.join(" ");
+const argCount = args.length;
 if (argCount < 5) {
-  console.error(`Error: too few arguments (${argCount}): ${args}`);
-  usage()
+  console.error(`Error: too few arguments (${argCount}): ${expression}`);
+  usage();
   process.exit(1);
 }
 
 if (argCount > 7) {
-  console.error(`Error: too many arguments (${argCount}): ${args}`);
+  console.error(`Error: too many arguments (${argCount}): ${expression}`);
   usage();
   process.exit(2);
 }
-console.log(cronstrue.toString(args));
+
+console.log(cronstrue.toString(expression));

--- a/test/cli-special-syntax.js
+++ b/test/cli-special-syntax.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+/**
+ * This file demonstrates how to use the CLI with special @ syntax expressions.
+ * It runs the CLI with various special expressions and shows the human-readable output.
+ * 
+ * Run with: node test/cli-special-syntax.js
+ */
+
+const { execSync } = require('child_process');
+const path = require('path');
+
+// Path to the CLI
+const cliPath = path.join(__dirname, '..', 'bin', 'cli.js');
+
+// Test various expressions
+const expressions = [
+  '@daily',
+  '@weekly',
+  '@monthly',
+  '@yearly',
+  '@annually',
+  '@midnight',
+  '@hourly',
+  '*/5 * * * *',
+  '0 0 * * 1',
+  '15 14 1 * *'
+];
+
+// Display the human-readable descriptions
+expressions.forEach(expr => {
+  console.log(`Expression: ${expr}`);
+  try {
+    const output = execSync(`node ${cliPath} "${expr}"`).toString().trim();
+    console.log(`Description: ${output}`);
+  } catch (e) {
+    console.log(`Error: ${e.message}`);
+  }
+  console.log('-'.repeat(50));
+});


### PR DESCRIPTION
## Summary
- Add ability to parse single argument expressions including @ syntax in the CLI
- Enhance usage text with examples of @ syntax and quoted expressions
- Maintain backward compatibility with space-separated arguments format
- Extends and completes work done in https://github.com/bradymholt/cRonstrue/pull/318

## Use Case
This enables tools like [cronex.nvim](https://github.com/fabridamicelli/cronex.nvim) to use the CLI for translating special @ syntax expressions like @daily and @monthly as seen in https://github.com/fabridamicelli/cronex.nvim/pull/8.

## Testing
Manual testing confirms that all special @ syntax formats and normal cron expressions work correctly:

```
Expression: @daily
Description: At 12:00 AM
--------------------------------------------------
Expression: @weekly
Description: At 12:00 AM, only on Sunday
--------------------------------------------------
Expression: @monthly
Description: At 12:00 AM, on day 1 of the month
--------------------------------------------------
Expression: @yearly
Description: At 12:00 AM, on day 1 of the month, only in January
--------------------------------------------------
Expression: @annually
Description: At 12:00 AM, on day 1 of the month, only in January
--------------------------------------------------
Expression: @midnight
Description: At 12:00 AM
--------------------------------------------------
Expression: @hourly
Description: Every hour
--------------------------------------------------
Expression: */5 * * * *
Description: Every 5 minutes
--------------------------------------------------
Expression: 0 0 * * 1
Description: At 12:00 AM, only on Monday
--------------------------------------------------
Expression: 15 14 1 * *
Description: At 02:15 PM, on day 1 of the month
--------------------------------------------------
```

The existing multi-argument format continues to work as before.

## Note
Core functionality for parsing @ syntax expressions already exists in the library and has its own tests in the test suite. This PR only enhances the CLI to access this functionality.