### PR TITLE
Add support for @reboot special syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This library was ported from the original C# implementation called [cron-express
 - Supports all cron expression special characters including * / , - ? L W, #
 - Supports 5, 6 (w/ seconds or year), or 7 (w/ seconds and year) part cron expressions
 - [Quartz Job Scheduler](http://www.quartz-scheduler.org/) cron expressions are supported
+- Supports time specification _nicknames_ (@yearly, @annually, @monthly, @weekly, @daily, @reboot)
 - i18n support with 30+ languages
 
 ## Demo
@@ -93,6 +94,9 @@ cronstrue.toString("* * * 6-8 *", { monthStartIndexZero: true });
 
 cronstrue.toString("@monthly");
 > "At 12:00 AM, on day 1 of the month"
+
+cronstrue.toString("@reboot");
+> "At system startup"
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ cronstrue.toString("@monthly");
 > "At 12:00 AM, on day 1 of the month"
 
 cronstrue.toString("@reboot");
-> "At system startup"
+> "Run once, at startup"
 
 ```
 

--- a/src/cronParser.ts
+++ b/src/cronParser.ts
@@ -10,11 +10,7 @@ export class CronParser {
   dayOfWeekStartIndexZero: boolean;
   monthStartIndexZero: boolean;
 
-  constructor(
-    expression: string,
-    dayOfWeekStartIndexZero: boolean = true,
-    monthStartIndexZero: boolean = false
-  ) {
+  constructor(expression: string, dayOfWeekStartIndexZero: boolean = true, monthStartIndexZero: boolean = false) {
     this.expression = expression;
     this.dayOfWeekStartIndexZero = dayOfWeekStartIndexZero;
     this.monthStartIndexZero = monthStartIndexZero;
@@ -27,12 +23,15 @@ export class CronParser {
   parse(): string[] {
     let parsed: string[];
 
-    var expression = this.expression ?? '';
+    var expression = this.expression ?? "";
 
-    if (expression.startsWith('@')) {
+    if (expression === "@reboot") {
+      // Special handling for @reboot - create a marker array with a special format
+      parsed = ["@reboot", "", "", "", "", "", ""];
+      return parsed;
+    } else if (expression.startsWith("@")) {
       var special = this.parseSpecial(this.expression);
       parsed = this.extractParts(special);
-
     } else {
       parsed = this.extractParts(this.expression);
     }
@@ -45,18 +44,19 @@ export class CronParser {
 
   parseSpecial(expression: string): string {
     const specialExpressions: { [key: string]: string } = {
-        '@yearly': '0 0 1 1 *',
-        '@annually': '0 0 1 1 *',
-        '@monthly': '0 0 1 * *',
-        '@weekly': '0 0 * * 0',
-        '@daily': '0 0 * * *',
-        '@midnight': '0 0 * * *',
-        '@hourly': '0 * * * *'
+      "@yearly": "0 0 1 1 *",
+      "@annually": "0 0 1 1 *",
+      "@monthly": "0 0 1 * *",
+      "@weekly": "0 0 * * 0",
+      "@daily": "0 0 * * *",
+      "@midnight": "0 0 * * *",
+      "@hourly": "0 * * * *",
+      "@reboot": "@reboot",
     };
 
     const special = specialExpressions[expression];
     if (!special) {
-        throw new Error('Unknown special expression.');
+      throw new Error("Unknown special expression.");
     }
 
     return special;
@@ -316,19 +316,18 @@ export class CronParser {
   }
 
   protected validate(parsed: string[]) {
-    const standardCronPartCharacters = "0-9,\\-*\/";
+    const standardCronPartCharacters = "0-9,\\-*/";
     this.validateOnlyExpectedCharactersFound(parsed[0], standardCronPartCharacters);
     this.validateOnlyExpectedCharactersFound(parsed[1], standardCronPartCharacters);
     this.validateOnlyExpectedCharactersFound(parsed[2], standardCronPartCharacters);
     // DOM
-    this.validateOnlyExpectedCharactersFound(parsed[3], "0-9,\\-*\/LW");
+    this.validateOnlyExpectedCharactersFound(parsed[3], "0-9,\\-*/LW");
     this.validateOnlyExpectedCharactersFound(parsed[4], standardCronPartCharacters);
     // DOW
-    this.validateOnlyExpectedCharactersFound(parsed[5], "0-9,\\-*\/L#");
+    this.validateOnlyExpectedCharactersFound(parsed[5], "0-9,\\-*/L#");
     this.validateOnlyExpectedCharactersFound(parsed[6], standardCronPartCharacters);
 
     this.validateAnyRanges(parsed);
-
   }
 
   protected validateAnyRanges(parsed: string[]) {

--- a/src/cronParser.ts
+++ b/src/cronParser.ts
@@ -10,7 +10,11 @@ export class CronParser {
   dayOfWeekStartIndexZero: boolean;
   monthStartIndexZero: boolean;
 
-  constructor(expression: string, dayOfWeekStartIndexZero: boolean = true, monthStartIndexZero: boolean = false) {
+  constructor(
+    expression: string,
+    dayOfWeekStartIndexZero: boolean = true,
+    monthStartIndexZero: boolean = false
+  ) {
     this.expression = expression;
     this.dayOfWeekStartIndexZero = dayOfWeekStartIndexZero;
     this.monthStartIndexZero = monthStartIndexZero;
@@ -23,13 +27,13 @@ export class CronParser {
   parse(): string[] {
     let parsed: string[];
 
-    var expression = this.expression ?? "";
+    var expression = this.expression ?? '';
 
     if (expression === "@reboot") {
       // Special handling for @reboot - create a marker array with a special format
       parsed = ["@reboot", "", "", "", "", "", ""];
       return parsed;
-    } else if (expression.startsWith("@")) {
+    } else if (expression.startsWith('@')) {
       var special = this.parseSpecial(this.expression);
       parsed = this.extractParts(special);
     } else {
@@ -44,19 +48,19 @@ export class CronParser {
 
   parseSpecial(expression: string): string {
     const specialExpressions: { [key: string]: string } = {
-      "@yearly": "0 0 1 1 *",
-      "@annually": "0 0 1 1 *",
-      "@monthly": "0 0 1 * *",
-      "@weekly": "0 0 * * 0",
-      "@daily": "0 0 * * *",
-      "@midnight": "0 0 * * *",
-      "@hourly": "0 * * * *",
-      "@reboot": "@reboot",
+        '@yearly': '0 0 1 1 *',
+        '@annually': '0 0 1 1 *',
+        '@monthly': '0 0 1 * *',
+        '@weekly': '0 0 * * 0',
+        '@daily': '0 0 * * *',
+        '@midnight': '0 0 * * *',
+        '@hourly': '0 * * * *',
+        '@reboot': '@reboot'
     };
 
     const special = specialExpressions[expression];
     if (!special) {
-      throw new Error("Unknown special expression.");
+        throw new Error('Unknown special expression.');
     }
 
     return special;
@@ -316,15 +320,15 @@ export class CronParser {
   }
 
   protected validate(parsed: string[]) {
-    const standardCronPartCharacters = "0-9,\\-*/";
+    const standardCronPartCharacters = "0-9,\\-*\/";
     this.validateOnlyExpectedCharactersFound(parsed[0], standardCronPartCharacters);
     this.validateOnlyExpectedCharactersFound(parsed[1], standardCronPartCharacters);
     this.validateOnlyExpectedCharactersFound(parsed[2], standardCronPartCharacters);
     // DOM
-    this.validateOnlyExpectedCharactersFound(parsed[3], "0-9,\\-*/LW");
+    this.validateOnlyExpectedCharactersFound(parsed[3], "0-9,\\-*\/LW");
     this.validateOnlyExpectedCharactersFound(parsed[4], standardCronPartCharacters);
     // DOW
-    this.validateOnlyExpectedCharactersFound(parsed[5], "0-9,\\-*/L#");
+    this.validateOnlyExpectedCharactersFound(parsed[5], "0-9,\\-*\/L#");
     this.validateOnlyExpectedCharactersFound(parsed[6], standardCronPartCharacters);
 
     this.validateAnyRanges(parsed);

--- a/src/expressionDescriptor.ts
+++ b/src/expressionDescriptor.ts
@@ -104,6 +104,12 @@ export class ExpressionDescriptor {
         this.options.monthStartIndexZero
       );
       this.expressionParts = parser.parse();
+
+      // Special handling for @reboot
+      if (this.expressionParts[0] === "@reboot") {
+        return "At system startup";
+      }
+
       var timeSegment = this.getTimeOfDayDescription();
       var dayOfMonthDesc = this.getDayOfMonthDescription();
       var monthDesc = this.getMonthDescription();

--- a/src/expressionDescriptor.ts
+++ b/src/expressionDescriptor.ts
@@ -107,7 +107,7 @@ export class ExpressionDescriptor {
 
       // Special handling for @reboot
       if (this.expressionParts[0] === "@reboot") {
-        return "At system startup";
+        return this.i18n.atReboot?.() || "Run once, at startup";
       }
 
       var timeSegment = this.getTimeOfDayDescription();

--- a/src/i18n/locale.ts
+++ b/src/i18n/locale.ts
@@ -80,4 +80,5 @@ export interface Locale {
    * @return {string[]} months of year
    */
   monthsOfTheYearInCase?(f?: number): string[];
+  atReboot?(): string;
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -176,4 +176,8 @@ export class en implements Locale {
       "December",
     ];
   }
+
+  atReboot() {
+    return "Run once, at startup";
+  }
 }

--- a/test/cronParser.ts
+++ b/test/cronParser.ts
@@ -61,5 +61,11 @@ describe("CronParser", function () {
     it("should parse cron @ expression", function () {
       assert.equal(new CronParser("@weekly").parse().length, 7);
     });
+
+    it("should parse @reboot expression", function () {
+      const parsedReboot = new CronParser("@reboot").parse();
+      assert.equal(parsedReboot.length, 7);
+      assert.equal(parsedReboot[0], "@reboot");
+    });
   });
 });

--- a/test/cronstrue.ts
+++ b/test/cronstrue.ts
@@ -719,6 +719,10 @@ describe("Cronstrue", function () {
     it("@hourly", function () {
       assert.equal(cronstrue.toString(this.test?.title as string), "Every hour");
     });
+
+    it("@reboot", function () {
+      assert.equal(cronstrue.toString(this.test?.title as string), "At system startup");
+    });
   });
 
   describe("verbose", function () {

--- a/test/cronstrue.ts
+++ b/test/cronstrue.ts
@@ -721,7 +721,7 @@ describe("Cronstrue", function () {
     });
 
     it("@reboot", function () {
-      assert.equal(cronstrue.toString(this.test?.title as string), "At system startup");
+      assert.equal(cronstrue.toString(this.test?.title as string), "Run once, at startup");
     });
   });
 


### PR DESCRIPTION
## Summary
- Added support for the missing `@reboot` syntax, which is commonly used in cron implementations
- Added `@reboot` to the list of supported special expressions in the CronParser class
- Created a special handler to return "At system startup" for @reboot in the ExpressionDescriptor
- Added comprehensive tests for the new functionality
- Updated README to document the @reboot support

## Test plan
- Added unit tests for both CronParser and ExpressionDescriptor classes
- Manual testing with various expressions to ensure compatibility with existing features