### PR TITLE
feat(az): add Azerbaijani locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ The following locales can be passed in for the `locale` option.  Thank you to th
 - en - English ([Brady Holt](https://github.com/bradymholt))
 - af - Afrikaans ([Michael van Niekerk](https://github.com/mvniekerk))
 - ar - Arabic ([Mohamed Nehad Shalabi](https://github.com/mohamednehad450))
+- az - Azerbaijani ([Jamal Kamaladdin](https://github.com/jamalkamaladdin))
 - be - Belarusian ([Kirill Mikulich](https://github.com/KirillMikulich))
 - bg - Bulgarian ([kamenf](https://github.com/kamenf))
 - ca - Catalan ([Francisco Javier Barrena](https://github.com/fjbarrena))

--- a/src/i18n/allLocales.ts
+++ b/src/i18n/allLocales.ts
@@ -38,3 +38,4 @@ export { my } from './locales/my'; // Malay
 export { bg } from './locales/bg'; // Bulgarian
 export { hr } from './locales/hr'; // Croatian
 export { sr } from './locales/sr'; // Serbian
+export { az } from "./locales/az"; // Azerbaijani

--- a/src/i18n/locales/az.ts
+++ b/src/i18n/locales/az.ts
@@ -1,0 +1,290 @@
+// Azerbaijani
+
+import { Locale } from "../locale";
+
+// When an ordinal is written after a digit, Azerbaijani uses the short suffix
+// form (as in "6-", "1-", "4-", "35-" followed by the suffix). Which suffix is
+// used follows the vowel harmony of the numeral as it is spoken, so the last
+// digit decides it, or the tens part when the number ends in zero.
+const ORDINAL_SUFFIX_BY_LAST_DIGIT: { [digit: number]: string } = {
+  1: "-ci",
+  2: "-ci",
+  3: "-cü",
+  4: "-cü",
+  5: "-ci",
+  6: "-cı",
+  7: "-ci",
+  8: "-ci",
+  9: "-cu",
+};
+
+const ORDINAL_SUFFIX_BY_TENS: { [tens: number]: string } = {
+  0: "-cı",
+  10: "-cu",
+  20: "-ci",
+  30: "-cu",
+  40: "-cı",
+  50: "-ci",
+};
+
+const DEFAULT_ORDINAL_SUFFIX = "-cı";
+
+/**
+ * Returns the ordinal suffix that fits the given number, or null when the value
+ * is not a single number - a list such as "10,20" then takes a plural phrase
+ * instead of an ordinal one.
+ */
+const ordinalSuffix = (value: string | undefined) => {
+  if (!value || !/^\d+$/.test(value)) {
+    return null;
+  }
+
+  const number = Number(value);
+  const lastDigit = number % 10;
+
+  return lastDigit
+    ? ORDINAL_SUFFIX_BY_LAST_DIGIT[lastDigit]
+    : ORDINAL_SUFFIX_BY_TENS[number % 100] || DEFAULT_ORDINAL_SUFFIX;
+};
+
+export class az implements Locale {
+  atX0SecondsPastTheMinuteGt20(): string | null {
+    return null;
+  }
+  atX0MinutesPastTheHourGt20(): string | null {
+    return null;
+  }
+  commaMonthX0ThroughMonthX1(): string | null {
+    return ", %s %s qədər";
+  }
+  commaYearX0ThroughYearX1(): string | null {
+    return ", %s ilindən %s ilinə qədər";
+  }
+
+  use24HourTimeFormatByDefault() {
+    return true;
+  }
+
+  anErrorOccuredWhenGeneratingTheExpressionD() {
+    return "İfadənin təsviri yaradılarkən xəta baş verdi. Cron ifadəsinin sintaksisini yoxlayın.";
+  }
+  everyMinute() {
+    return "hər dəqiqə";
+  }
+  everyHour() {
+    return "hər saat";
+  }
+  atSpace() {
+    return "Saat ";
+  }
+  everyMinuteBetweenX0AndX1() {
+    return "Saat %s ilə %s arasında hər dəqiqə";
+  }
+  at() {
+    return "Saat";
+  }
+  spaceAnd() {
+    return " və";
+  }
+  everySecond() {
+    return "hər saniyə";
+  }
+  everyX0Seconds() {
+    return "hər %s saniyədən bir";
+  }
+  secondsX0ThroughX1PastTheMinute() {
+    return "dəqiqənin %s ilə %s saniyələri arasında";
+  }
+  atX0SecondsPastTheMinute(s?: string) {
+    const suffix = ordinalSuffix(s);
+    return suffix ? `dəqiqənin %s${suffix} saniyəsində` : "dəqiqənin %s saniyələrində";
+  }
+  everyX0Minutes() {
+    return "hər %s dəqiqədən bir";
+  }
+  minutesX0ThroughX1PastTheHour() {
+    return "saatın %s ilə %s dəqiqələri arasında";
+  }
+  atX0MinutesPastTheHour(s?: string) {
+    const suffix = ordinalSuffix(s);
+    return suffix ? `saatın %s${suffix} dəqiqəsində` : "saatın %s dəqiqələrində";
+  }
+  everyX0Hours() {
+    return "hər %s saatdan bir";
+  }
+  betweenX0AndX1() {
+    return "saat %s ilə %s arasında";
+  }
+  atX0() {
+    return "saat %s";
+  }
+  commaEveryDay() {
+    return ", hər gün";
+  }
+  commaEveryX0DaysOfTheWeek() {
+    return ", həftənin hər %s günündən bir";
+  }
+  commaX0ThroughX1() {
+    return ", %s %s qədər";
+  }
+  commaAndX0ThroughX1() {
+    return ", %s %s qədər";
+  }
+  first() {
+    return "birinci";
+  }
+  second() {
+    return "ikinci";
+  }
+  third() {
+    return "üçüncü";
+  }
+  fourth() {
+    return "dördüncü";
+  }
+  fifth() {
+    return "beşinci";
+  }
+  commaOnThe() {
+    return ", ayın ";
+  }
+  spaceX0OfTheMonth() {
+    return " %s günü";
+  }
+  lastDay() {
+    return "son gün";
+  }
+  commaOnTheLastX0OfTheMonth() {
+    return ", ayın son %s günü";
+  }
+  commaOnlyOnX0() {
+    return ", yalnız %s";
+  }
+  commaAndOnX0() {
+    return ", həmçinin %s";
+  }
+  commaEveryX0Months() {
+    return ", hər %s aydan bir";
+  }
+  commaOnlyInX0() {
+    return ", yalnız %s";
+  }
+  commaOnlyInYearX0() {
+    return ", yalnız %s ili";
+  }
+  commaOnTheLastDayOfTheMonth() {
+    return ", ayın son günü";
+  }
+  commaOnTheLastWeekdayOfTheMonth() {
+    return ", ayın son iş günü";
+  }
+  commaDaysBeforeTheLastDayOfTheMonth() {
+    return ", ayın son günündən %s gün əvvəl";
+  }
+  firstWeekday() {
+    return "ilk iş günü";
+  }
+  weekdayNearestDayX0() {
+    return "%s tarixinə ən yaxın iş günü";
+  }
+  commaOnTheX0OfTheMonth() {
+    return ", ayın %s";
+  }
+  commaEveryX0Days() {
+    return ", ayda hər %s gündən bir";
+  }
+  commaBetweenDayX0AndX1OfTheMonth() {
+    return ", ayın %s ilə %s günləri arasında";
+  }
+  commaOnDayX0OfTheMonth(s?: string) {
+    const suffix = ordinalSuffix(s);
+    return suffix ? `, ayın %s${suffix} günü` : ", ayın %s günləri";
+  }
+  commaEveryX0Years() {
+    return ", hər %s ildən bir";
+  }
+  commaStartingX0() {
+    return ", %s başlamaqla";
+  }
+  daysOfTheWeek() {
+    return ["bazar", "bazar ertəsi", "çərşənbə axşamı", "çərşənbə", "cümə axşamı", "cümə", "şənbə"];
+  }
+  // A range reads "from X to Y", so the first day takes the ablative case and
+  // the second one the dative. A single day keeps the plain nominative form.
+  daysOfTheWeekInCase(f: number = 0) {
+    switch (f) {
+      case 1:
+        return [
+          "bazardan",
+          "bazar ertəsindən",
+          "çərşənbə axşamından",
+          "çərşənbədən",
+          "cümə axşamından",
+          "cümədən",
+          "şənbədən",
+        ];
+      case 2:
+        return ["bazara", "bazar ertəsinə", "çərşənbə axşamına", "çərşənbəyə", "cümə axşamına", "cüməyə", "şənbəyə"];
+      default:
+        return this.daysOfTheWeek();
+    }
+  }
+  // A single month is always read as "only in <month>", and a month range as
+  // "from <month> to <month>", so the names are declined here rather than left
+  // in the nominative and glued to a preposition that Azerbaijani does not have.
+  monthsOfTheYear() {
+    return [
+      "yanvarda",
+      "fevralda",
+      "martda",
+      "apreldə",
+      "mayda",
+      "iyunda",
+      "iyulda",
+      "avqustda",
+      "sentyabrda",
+      "oktyabrda",
+      "noyabrda",
+      "dekabrda",
+    ];
+  }
+  monthsOfTheYearInCase(f: number = 0) {
+    return f == 1
+      ? [
+          "yanvardan",
+          "fevraldan",
+          "martdan",
+          "apreldən",
+          "maydan",
+          "iyundan",
+          "iyuldan",
+          "avqustdan",
+          "sentyabrdan",
+          "oktyabrdan",
+          "noyabrdan",
+          "dekabrdan",
+        ]
+      : [
+          "yanvara",
+          "fevrala",
+          "marta",
+          "aprelə",
+          "maya",
+          "iyuna",
+          "iyula",
+          "avqusta",
+          "sentyabra",
+          "oktyabra",
+          "noyabra",
+          "dekabra",
+        ];
+  }
+
+  atReboot() {
+    return "Başlanğıcda bir dəfə icra olunur";
+  }
+
+  onTheHour() {
+    return "saat başında";
+  }
+}

--- a/test/i18n.ts
+++ b/test/i18n.ts
@@ -627,5 +627,38 @@ describe("i18n", function () {
     });
   });
 
+  describe("az", function () {
+    it("* * * * *", function () {
+      assert.equal(cronstrue.toString(this.test?.title as string, { locale: "az" }), "Hər dəqiqə");
+    });
+
+    it("0 * * * *", function () {
+      assert.equal(cronstrue.toString(this.test?.title as string, { locale: "az" }), "Hər saat");
+    });
+
+    it("*/5 15 * * MON-FRI", function () {
+      assert.equal(
+        cronstrue.toString(this.test?.title as string, { locale: "az" }),
+        "Hər 5 dəqiqədən bir, saat 15:00 ilə 15:59 arasında, bazar ertəsindən cüməyə qədər"
+      );
+    });
+
+    // The ordinal suffix follows vowel harmony, so it is not the same for every number.
+    it("0 0 3 * *", function () {
+      assert.equal(cronstrue.toString(this.test?.title as string, { locale: "az" }), "Saat 00:00, ayın 3-cü günü");
+    });
+
+    it("0 0 9 * *", function () {
+      assert.equal(cronstrue.toString(this.test?.title as string, { locale: "az" }), "Saat 00:00, ayın 9-cu günü");
+    });
+
+    it("23 12 * JAN-MAR *", function () {
+      assert.equal(
+        cronstrue.toString(this.test?.title as string, { locale: "az" }),
+        "Saat 12:23, yanvardan marta qədər"
+      );
+    });
+  });
+
 
 });


### PR DESCRIPTION
Adds the `az` (Azerbaijani) locale.

### Sources

Weekday and month names were cross-checked against three independent sources rather than translated by hand — two of them are Azerbaijani locales that already ship in widely used libraries:

- [moment/moment `locale/az.js`](https://github.com/moment/moment/blob/develop/locale/az.js)
- [flatpickr `src/l10n/az.ts`](https://github.com/flatpickr/flatpickr/blob/master/src/l10n/az.ts)
- Azerbaijani Wikipedia — [Həftə](https://az.wikipedia.org/wiki/H%C9%99ft%C9%99)

All three agree on the same forms, and those are the ones used here.

### Ordinal suffixes

An Azerbaijani ordinal written after a digit takes a short suffix chosen by the vowel harmony of the spoken numeral: `1-ci`, `3-cü`, `6-cı`, `9-cu`, `10-cu`, `20-ci`, `30-cu`, `40-cı`. Any single fixed suffix would be wrong for most numbers, so `ordinalSuffix()` derives it from the last digit, or from the tens part when the number ends in zero. The rule and its examples come from [Sıra sayı](https://az.wikipedia.org/wiki/S%C4%B1ra_say%C4%B1) (`6-cı`, `1-ci`, `4-cü`, `35-ci`); the table reproduces every published example.

When the value is not a single number (`10,20`) there is no ordinal to form, so the phrase switches to the plural: `saatın 10 və 20 dəqiqələrində`.

### Grammatical cases

Azerbaijani has no prepositions, so ranges are carried by case endings. `daysOfTheWeekInCase` returns the ablative for the start of a range and the dative for its end, which makes `MON-FRI` read `bazar ertəsindən cüməyə qədər`; a single day keeps the nominative. `monthsOfTheYear` is declined for the same reason — a single month is only ever read as "only in \<month\>", and a range uses `monthsOfTheYearInCase`.

`use24HourTimeFormatByDefault` is `true`, as Azerbaijan uses the 24-hour clock.

### Sample output

| expression | description |
|---|---|
| `* * * * *` | Hər dəqiqə |
| `*/5 15 * * MON-FRI` | Hər 5 dəqiqədən bir, saat 15:00 ilə 15:59 arasında, bazar ertəsindən cüməyə qədər |
| `0 0 15 * *` | Saat 00:00, ayın 15-ci günü |
| `0 0 * * 5#3` | Saat 00:00, ayın üçüncü cümə günü |
| `0 0 L-3 * *` | Saat 00:00, ayın son günündən 3 gün əvvəl |
| `23 12 * JAN-MAR *` | Saat 12:23, yanvardan marta qədər |

### Checks

`npm test` passes with 326 tests, including 6 new `az` cases; two of them cover the ordinal harmony (`3-cü` against `9-cu`) so a regression in the suffix table cannot pass silently.
