### PR TITLE
add Tajik i18n locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ The following locales can be passed in for the `locale` option.  Thank you to th
 - sw - Swahili ([Leylow Lujuo](https://github.com/leyluj))
 - sv - Swedish ([roobin](https://github.com/roobin))
 - sr - Serbian ([Miloš Paunović](https://github.com/MilosPaunovic))
+- tg - Tajik ([Ismoil Vakhidov](https://github.com/ismoil77))
 - th - Thai ([Teerapat Prommarak](https://github.com/xeusteerapat))
 - tr - Turkish ([Mustafa SADEDİL](https://github.com/sadedil))
 - uk - Ukrainian ([Taras](https://github.com/tbudurovych))

--- a/src/i18n/allLocales.ts
+++ b/src/i18n/allLocales.ts
@@ -15,6 +15,7 @@ export { pt_BR } from "./locales/pt_BR"; // Portuguese (Brazil)
 export { pt_PT } from "./locales/pt_PT"; // Portuguese (Portugal)
 export { ro } from "./locales/ro"; // Romanian
 export { ru } from "./locales/ru"; // Russian
+export { tg } from "./locales/tg"; // Tajik
 export { tr } from "./locales/tr"; // Turkish
 export { uk } from "./locales/uk"; // Ukrainian
 export { zh_CN } from "./locales/zh_CN"; // Chinese (Simplified)

--- a/src/i18n/locales/tg.ts
+++ b/src/i18n/locales/tg.ts
@@ -1,0 +1,207 @@
+// Tajik
+
+import { Locale } from "../locale";
+
+const weekdays = ["якшанбе", "душанбе", "сешанбе", "чоршанбе", "панҷшанбе", "ҷумъа", "шанбе"];
+
+const months = [
+  "январ",
+  "феврал",
+  "март",
+  "апрел",
+  "май",
+  "июн",
+  "июл",
+  "август",
+  "сентябр",
+  "октябр",
+  "ноябр",
+  "декабр",
+];
+
+// izafa form, used when the month is followed by a day, e.g. "январи 5"
+const monthsIzafa = [
+  "январи",
+  "феврали",
+  "марти",
+  "апрели",
+  "майи",
+  "июни",
+  "июли",
+  "августи",
+  "сентябри",
+  "октябри",
+  "ноябри",
+  "декабри",
+];
+
+export class tg implements Locale {
+  atX0SecondsPastTheMinuteGt20(): string | null {
+    return null;
+  }
+  atX0MinutesPastTheHourGt20(): string | null {
+    return null;
+  }
+  commaMonthX0ThroughMonthX1(): string | null {
+    return null;
+  }
+  commaYearX0ThroughYearX1(): string | null {
+    return null;
+  }
+  use24HourTimeFormatByDefault() {
+    return true;
+  }
+  anErrorOccuredWhenGeneratingTheExpressionD() {
+    return "Ҳангоми тавсифи ифодаи cron хато рӯй дод. Синтаксисро санҷед.";
+  }
+  everyMinute() {
+    return "ҳар дақиқа";
+  }
+  everyHour() {
+    return "ҳар соат";
+  }
+  atSpace() {
+    return "Дар ";
+  }
+  everyMinuteBetweenX0AndX1() {
+    return "Ҳар дақиқа аз %s то %s";
+  }
+  at() {
+    return "Дар";
+  }
+  spaceAnd() {
+    return " ва";
+  }
+  everySecond() {
+    return "ҳар сония";
+  }
+  everyX0Seconds() {
+    return "ҳар %s сония";
+  }
+  secondsX0ThroughX1PastTheMinute() {
+    return "сонияҳои аз %s то %s";
+  }
+  atX0SecondsPastTheMinute() {
+    return "дар %s сония";
+  }
+  everyX0Minutes() {
+    return "ҳар %s дақиқа";
+  }
+  minutesX0ThroughX1PastTheHour() {
+    return "дақиқаҳои аз %s то %s";
+  }
+  atX0MinutesPastTheHour() {
+    return "дар %s дақиқа";
+  }
+  everyX0Hours() {
+    return "ҳар %s соат";
+  }
+  betweenX0AndX1() {
+    return "аз %s то %s";
+  }
+  atX0() {
+    return "дар %s";
+  }
+  commaEveryDay() {
+    return ", ҳар рӯз";
+  }
+  commaEveryX0DaysOfTheWeek() {
+    return ", ҳар %s рӯзи ҳафта";
+  }
+  commaX0ThroughX1() {
+    return ", аз %s то %s";
+  }
+  commaAndX0ThroughX1() {
+    return " ва аз %s то %s";
+  }
+  first() {
+    return "якум";
+  }
+  second() {
+    return "дуюм";
+  }
+  third() {
+    return "сеюм";
+  }
+  fourth() {
+    return "чорум";
+  }
+  fifth() {
+    return "панҷум";
+  }
+  commaOnThe() {
+    return ", дар ";
+  }
+  spaceX0OfTheMonth() {
+    return " %s-и моҳ";
+  }
+  lastDay() {
+    return "рӯзи охирин";
+  }
+  commaOnTheLastX0OfTheMonth() {
+    return ", дар охирин %s-и моҳ";
+  }
+  commaOnlyOnX0() {
+    return ", танҳо дар %s";
+  }
+  commaAndOnX0() {
+    return ", ва %s";
+  }
+  commaEveryX0Months() {
+    return " ҳар %s моҳ";
+  }
+  commaOnlyInMonthX0() {
+    return ", танҳо %s";
+  }
+  commaOnlyInX0() {
+    return ", танҳо дар %s";
+  }
+  commaOnTheLastDayOfTheMonth() {
+    return ", дар рӯзи охирини моҳ";
+  }
+  commaOnTheLastWeekdayOfTheMonth() {
+    return ", дар охирин рӯзи кории моҳ";
+  }
+  commaDaysBeforeTheLastDayOfTheMonth() {
+    return ", %s рӯз пеш аз охири моҳ";
+  }
+  firstWeekday() {
+    return "якумин рӯзи корӣ";
+  }
+  weekdayNearestDayX0() {
+    return "наздиктарин рӯзи корӣ ба %s";
+  }
+  commaOnTheX0OfTheMonth() {
+    return ", дар %s-и моҳ";
+  }
+  commaEveryX0Days() {
+    return ", ҳар %s рӯз";
+  }
+  commaBetweenDayX0AndX1OfTheMonth() {
+    return ", аз рӯзи %s то %s-и моҳ";
+  }
+  commaOnDayX0OfTheMonth() {
+    return ", дар рӯзи %s-и моҳ";
+  }
+  commaEveryX0Years() {
+    return ", ҳар %s сол";
+  }
+  commaStartingX0() {
+    return ", оғоз %s";
+  }
+  daysOfTheWeek() {
+    return [...weekdays];
+  }
+  daysOfTheWeekInCase() {
+    return [...weekdays];
+  }
+  monthsOfTheYear() {
+    return [...months];
+  }
+  monthsOfTheYearInCase(f?: number) {
+    return f == 1 ? [...monthsIzafa] : [...months];
+  }
+  onTheHour() {
+    return "дақиқан дар соат";
+  }
+}

--- a/test/i18n.ts
+++ b/test/i18n.ts
@@ -377,6 +377,23 @@ describe("i18n", function () {
     });
   });
 
+  describe("tg", function () {
+    it("* * * * *", function () {
+      assert.equal(cronstrue.toString(this.test?.title as string, { locale: "tg" }), "Ҳар дақиқа");
+    });
+
+    it("*/5 15 * * MON-FRI", function () {
+      assert.equal(
+        cronstrue.toString(this.test?.title as string, { locale: "tg" }),
+        "Ҳар 5 дақиқа, аз 15:00 то 15:59, аз душанбе то ҷумъа"
+      );
+    });
+
+    it("0 0 L * *", function () {
+      assert.equal(cronstrue.toString(this.test?.title as string, { locale: "tg" }), "Дар 00:00, дар рӯзи охирини моҳ");
+    });
+  });
+
   describe("sl", function () {
     it("* * * * *", function () {
       assert.equal(cronstrue.toString(this.test?.title as string, { locale: "sl" }), "Vsako minuto");


### PR DESCRIPTION
Adds the Tajik (`tg`) locale.

The translation comes from an app I maintain, where cronstrue describes scheduling rules for Tajik speaking users. The package has no Tajik locale, so it was registered locally with `cronstrue.locales.tj = ...` — this PR upstreams it under the ISO 639-1 code `tg`.

Same four files as #106:

- `src/i18n/locales/tg.ts`
- `src/i18n/allLocales.ts`
- `test/i18n.ts` — three cases
- `README.md`

Examples:

| expression | description |
| --- | --- |
| `* * * * *` | Ҳар дақиқа |
| `*/5 15 * * MON-FRI` | Ҳар 5 дақиқа, аз 15:00 то 15:59, аз душанбе то ҷумъа |
| `0 9 * * 1-5` | Дар 09:00, аз душанбе то ҷумъа |
| `0 0 L * *` | Дар 00:00, дар рӯзи охирини моҳ |
| `0 0 LW * *` | Дар 00:00, дар охирин рӯзи кории моҳ |
| `0 0 15W * *` | Дар 00:00, дар наздиктарин рӯзи корӣ ба 15-и моҳ |
| `30 2 1 1 *` | Дар 02:30, дар рӯзи 1-и моҳ, танҳо январ |

A few notes on the translation:

- `monthsOfTheYearInCase` returns the izafa form (`январи`, `феврали`, …), which Tajik uses when the month is followed by a day.
- `use24HourTimeFormatByDefault` returns `true`, like `ru` and `uk` — Tajik uses the 24 hour clock.
- The optional members (`am`, `pm`, `atReboot`, `dayX0`, …) are left out, the same way `ru`, `uk`, `tr` and `fa` do.

`npm test` passes (323 tests) and `npm run build` is clean.
