### PR TITLE
ci: upgrade actions off deprecated Node.js runtimes and refresh test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,9 @@ jobs:
       matrix:
         node-version: [16, 18]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Install Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16, 18]
+        node-version: [20, 22, 24]
     steps:
       - uses: actions/checkout@v7
       - name: Install Node.js ${{ matrix.node-version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,7 +57,7 @@ jobs:
           zip -gr assets.zip dist/ locales/
       - name: Create a Release
         id: create-release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.push.outputs.tag-name }}
           generate_release_notes: true


### PR DESCRIPTION
Fixes the deprecation warning on the Publish workflow:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `softprops/action-gh-release@v1`.

## Changes

**`.github/workflows/publish.yml`** — `softprops/action-gh-release` v1 → **v3**.

Note that v2 does *not* resolve this: its `action.yml` still declares `using: node20`, and the maintainer kept 2.6.2 as the last Node 20 release. v3.0.0 is the runtime bump to `node24` and carries no other breaking change. I verified against v3's `action.yml` that everything this workflow depends on is unchanged — the `tag_name`, `generate_release_notes` and `files` inputs, and the `id` output that the following `github-script` step reads.

**`.github/workflows/build.yml`** — `actions/checkout` v3 → **v7** and `actions/setup-node` v3 → **v6**, matching the versions already in use in `publish.yml`. These weren't in the warning above (Build didn't run), but the v3 majors declare `node16` and would emit the same warning on the next Build run.

**`.github/workflows/build.yml`** — test matrix `[16, 18]` → **`[20, 22, 24]`**. Node 16 and 18 are both past end-of-life.

## Testing

Full suite run locally on each version in the new matrix — 329 passing on Node 20.20.2, 22.22.2 and 24.20.0.

## Note

This drops CI coverage for Node 16 and 18. There is no `engines` field in `package.json`, so nothing formally declares support for them — they are now untested rather than unsupported. Worth adding an explicit `engines` entry if there's a runtime floor you want to commit to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Chq7cbqLCon4owMmQ1TqmG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Chq7cbqLCon4owMmQ1TqmG)_