### PR TITLE
verbose: spell out the values of a step that doesn't divide the field evenly

### DIFF
--- a/src/expressionDescriptor.ts
+++ b/src/expressionDescriptor.ts
@@ -237,7 +237,8 @@ export class ExpressionDescriptor {
           : parseInt(s) < 20
           ? this.i18n.atX0SecondsPastTheMinute(s)
           : this.i18n.atX0SecondsPastTheMinuteGt20() || this.i18n.atX0SecondsPastTheMinute(s);
-      }
+      },
+      { min: 0, max: 59 }
     );
 
     return description;
@@ -270,7 +271,8 @@ export class ExpressionDescriptor {
         } catch (e) {
           return this.i18n.atX0MinutesPastTheHour(s);
         }
-      }
+      },
+      { min: 0, max: 59 }
     );
 
     return description;
@@ -313,7 +315,8 @@ export class ExpressionDescriptor {
       },
       (s) => {
         return this.i18n.atX0();
-      }
+      },
+      { min: 0, max: 23 }
     );
 
     return description;
@@ -537,7 +540,8 @@ export class ExpressionDescriptor {
     getSingleItemDescription: (t: string, form?: number) => string,
     getIncrementDescriptionFormat: (t: string) => string,
     getRangeDescriptionFormat: (t: string) => string,
-    getDescriptionFormat: (t: string) => string
+    getDescriptionFormat: (t: string) => string,
+    range?: { min: number; max: number }
   ): string | null {
     let description: string | null = null;
     const doesExpressionContainIncrement = expression.indexOf("/") > -1;
@@ -646,6 +650,16 @@ export class ExpressionDescriptor {
 
         description += StringUtilities.format(this.i18n.commaStartingX0(), rangeItemDescription);
       }
+
+      description += this.getWrappingIncrementDescription(
+        expression,
+        range,
+        allDescription,
+        getSingleItemDescription,
+        getIncrementDescriptionFormat,
+        getRangeDescriptionFormat,
+        getDescriptionFormat
+      );
     } else if (doesExpressionContainRange) {
       // Range
 
@@ -657,6 +671,60 @@ export class ExpressionDescriptor {
     }
 
     return description;
+  }
+
+  /**
+   * A step which doesn't divide the field evenly (e.g. minute "*\/50") matches the values 0 and 50,
+   * so the gaps alternate between 50 and 10 minutes instead of being a constant interval.
+   * In verbose mode, spell out the matched values after the increment description by reusing
+   * the description of the equivalent list expression ("0,50").
+   */
+  protected getWrappingIncrementDescription(
+    expression: string,
+    range: { min: number; max: number } | undefined,
+    allDescription: string,
+    getSingleItemDescription: (t: string, form?: number) => string,
+    getIncrementDescriptionFormat: (t: string) => string,
+    getRangeDescriptionFormat: (t: string) => string,
+    getDescriptionFormat: (t: string) => string
+  ): string {
+    if (!this.options.verbose || !range) {
+      return "";
+    }
+
+    const [start, stepValue] = expression.split("/");
+    const step = parseInt(stepValue);
+    const length = range.max - range.min + 1;
+
+    // Only a step over the whole field wraps around: a range with a step ("2-30/7") already
+    // states its bounds, and an evenly dividing step ("*\/15") really is a constant interval.
+    const coversWholeField = start === "*";
+    const isUsableStep = Number.isInteger(step) && step > 1;
+    const dividesEvenly = isUsableStep && length % step === 0;
+
+    if (!coversWholeField || !isUsableStep || dividesEvenly) {
+      return "";
+    }
+
+    const values: number[] = [];
+    for (let value = range.min; value <= range.max; value += step) {
+      values.push(value);
+    }
+
+    if (values.length < 2) {
+      return "";
+    }
+
+    const valuesDescription = this.getSegmentDescription(
+      values.join(","),
+      allDescription,
+      getSingleItemDescription,
+      getIncrementDescriptionFormat,
+      getRangeDescriptionFormat,
+      getDescriptionFormat
+    );
+
+    return valuesDescription ? `, ${valuesDescription}` : "";
   }
 
   protected generateRangeSegmentDescription(

--- a/test/cronstrue.ts
+++ b/test/cronstrue.ts
@@ -795,6 +795,60 @@ describe("Cronstrue", function () {
     it("0 13 * * 1", function () {
       assert.equal(cronstrue.toString(this.test?.title as string, { verbose: true }), "At 01:00 PM, only on Monday");
     });
+
+    // A step which doesn't divide the field evenly spells out the values it matches
+    it("*/50 * * * *", function () {
+      assert.equal(cronstrue.toString(this.test?.title as string), "Every 50 minutes");
+      assert.equal(
+        cronstrue.toString(this.test?.title as string, { verbose: true }),
+        "Every 50 minutes, at 0 and 50 minutes past the hour, every hour, every day"
+      );
+    });
+
+    it("*/7 * * * *", function () {
+      assert.equal(
+        cronstrue.toString(this.test?.title as string, { verbose: true }),
+        "Every 7 minutes, at 0, 7, 14, 21, 28, 35, 42, 49, and 56 minutes past the hour, every hour, every day"
+      );
+    });
+
+    it("*/59 * * * *", function () {
+      assert.equal(
+        cronstrue.toString(this.test?.title as string, { verbose: true }),
+        "Every 59 minutes, at 0 and 59 minutes past the hour, every hour, every day"
+      );
+    });
+
+    it("0 */7 * * *", function () {
+      assert.equal(
+        cronstrue.toString(this.test?.title as string, { verbose: true }),
+        "On the hour, every 7 hours, at 12:00 AM, 07:00 AM, 02:00 PM, and 09:00 PM, every day"
+      );
+    });
+
+    it("*/50 * * * * *", function () {
+      assert.equal(
+        cronstrue.toString(this.test?.title as string, { verbose: true }),
+        "Every 50 seconds, at 0 and 50 seconds past the minute, every minute, every hour, every day"
+      );
+    });
+
+    // A step which divides the field evenly is a constant interval and stays as it is
+    it("*/15 * * * *", function () {
+      assert.equal(cronstrue.toString(this.test?.title as string, { verbose: true }), "Every 15 minutes, every hour, every day");
+    });
+
+    it("*/30 * * * *", function () {
+      assert.equal(cronstrue.toString(this.test?.title as string, { verbose: true }), "Every 30 minutes, every hour, every day");
+    });
+
+    // A range with a step already states its bounds
+    it("5-30/7 * * * *", function () {
+      assert.equal(
+        cronstrue.toString(this.test?.title as string, { verbose: true }),
+        "Every 7 minutes, minutes 5 through 30 past the hour, every hour, every day"
+      );
+    });
   });
 
   describe("errors", function () {


### PR DESCRIPTION
Closes #378.

Under `verbose: true`, a step which doesn't divide its field evenly now spells out the values it matches, as discussed in #378:

```js
cronstrue.toString("*/50 * * * *")                     // Every 50 minutes   (unchanged)
cronstrue.toString("*/50 * * * *", { verbose: true })  // Every 50 minutes, at 0 and 50 minutes past the hour, every hour, every day
```

The default output doesn't change at all. The clarification is only added when

- the step covers the whole field (`*/N`) — a range with a step (`5-30/7`) already states its bounds, and
- the field length isn't a multiple of the step — `*/15`, `*/20` and `*/30` are real constant intervals and stay as they are.

It applies to seconds, minutes and hours, whose ranges are fixed. Day of month is left out on purpose: its length depends on the month, so any enumeration would be wrong for some of them.

The added text is the description of the equivalent list expression (`0,50`), generated by the same code path, so every locale gets it without new translations:

```
en  Every 50 minutes, at 0 and 50 minutes past the hour, …
ru  Каждые 50 минут, в 0 и 50 минут, …
de  Alle 50 Minuten, bei Minute 0 und 50, …
tg  Ҳар 50 дақиқа, дар 0 ва 50 дақиқа, …
```

Implementation: `getSegmentDescription` takes an optional `range`, passed by the seconds, minutes and hours callers; the increment branch appends `getWrappingIncrementDescription`, which recurses into `getSegmentDescription` with the enumerated values.

Tests cover uneven steps for seconds, minutes and hours, the unchanged output for `*/15`, `*/30` and `5-30/7`, and the unchanged non-verbose output. `npm test` passes and `npm run build` is clean.
