### PR TITLE
Add TODO section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ Thank you to the following sponsors of this project!
 <a href="https://github.com/timheuer"><img src="https://github.com/timheuer.png" width="50px" alt="robjtede" style="max-width: 100%;"></a>
 
 
+## TODO
+
 ## License
 
 cRonstrue is freely distributable under the terms of the [MIT license](https://github.com/bradymholt/cronstrue/blob/main/LICENSE).


### PR DESCRIPTION
Adds a `TODO` section heading to the README, above the License section. The section has no content yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)